### PR TITLE
Stats

### DIFF
--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -342,7 +342,7 @@ class HklFrame(BaseFrame):
     HklFrame methods are designed to work in-place, so the work strategy
     is to create a new instance of HklFrame for each reflection dataset,
     manipulate it using methods, eg. :func:`merge` or :func:`trim`, and
-    :func:`duplicate` to other object or output using :func:`write` if needed.
+    :func:`copy` to other object or output using :func:`write` if needed.
 
     The HklFrame always initiates empty and does not accept any arguments.
     Some of the magic methods, such as :func:`__len__` and :func:`__add__`
@@ -379,7 +379,7 @@ class HklFrame(BaseFrame):
         :return: concatenated :attr:`table` dataframes, with metadata from first
         :rtype: HklFrame
         """
-        _copied = self.duplicate()
+        _copied = self.copy()
         _copied.table = pd.concat([self.table, other.table], ignore_index=True)
         return _copied
 
@@ -497,11 +497,9 @@ class HklFrame(BaseFrame):
         self.table = self.table[in_torus1 * in_torus2]
         self.table.reset_index(drop=True, inplace=True)
 
-    def duplicate(self):
+    def copy(self):
         """
-        Make and return an exact deep copy of this HklFrame.
-
-        :return: A copy of this HklFrame.
+        :return: An exact deep copy of this HklFrame.
         :rtype: HklFrame
         """
         return copy.deepcopy(self)
@@ -614,11 +612,11 @@ class HklFrame(BaseFrame):
 
         #TODO this function doesn't make sense for merged data
 
-        hkl_base = self.duplicate()
+        hkl_base = self.copy()
         hkl_base.extinct(space_group)
 
         def prepare_ball_of_hkl(_point_group=PG['1']):
-            _hkl_full = hkl_base.duplicate()
+            _hkl_full = hkl_base.copy()
             _hkl_full.fill(radius=max(self.table['r']))
             _hkl_full.merge(point_group=_point_group)
             _hkl_full.extinct(space_group)
@@ -627,7 +625,7 @@ class HklFrame(BaseFrame):
         hkl_full = prepare_ball_of_hkl(_point_group=space_group)
 
         def prepare_merged_hkl(_point_group=PG['1']):
-            _hkl_merged_pg1 = hkl_base.duplicate()
+            _hkl_merged_pg1 = hkl_base.copy()
             _hkl_merged_pg1.merge(point_group=_point_group)
             return _hkl_merged_pg1
 

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -600,22 +600,18 @@ class HklFrame(BaseFrame):
         self.from_dict({'h': np.array(_h)[0], 'k': np.array(_k)[0],
                         'l': np.array(_l)[0], 'I': ones, 'si': ones, 'm': ones})
 
-    def stats(self, bins=10, space_group=PG['1']):
+    def stats(self, bins=10, space_group=SG['P1']):
         """
-        Analyses dataframe in terms of number of individual, unique and
-        theoretically possible reflections, as well as completeness and
-        redundancy in given point group.
+        Prints completeness, redundancy, number of all, unique and theoretically
+        possible reflections within equal-volume `bins` in given `space group`.
 
-        Point group is necessary to correctly specify symmetry equivalence
-        and it has been described for method :meth:`merge` in detail.
-        List of extinctions is necessary to correctly extinct the reference data
-        and it has been for method :meth:`extinct` in detail.
-
-        :param bins: Number of individual bins to divide the data into.
+        :param bins: Number of equal-volume bins to divide the data into.
         :type bins: int
-        :param space_group: Space group used to calculate the statistics.
+        :param space_group: Group used to calculate equivalence and extinctions.
         :type space_group: hikari.symmetry.Group
+        :returns
         """
+
         #TODO this function doesn't make sense for merged data
 
         hkl_base = self.duplicate()

--- a/hikari/scripts/hkl.py
+++ b/hikari/scripts/hkl.py
@@ -17,7 +17,7 @@ import numpy.linalg as lin
 
 
 def completeness_statistics(a, b, c, al, be, ga,
-                            point_group=PG['-1'],
+                            space_group=SG['P-1'],
                             input_path='shelx.hkl',
                             input_format=4,
                             input_wavelength='CuKa'):
@@ -37,9 +37,8 @@ def completeness_statistics(a, b, c, al, be, ga,
     :type be: float
     :param ga: Unit cell parameter *alpha* in degrees.
     :type ga: float
-    :param point_group: Point group of the crystal,
-        defined as an instance of :class:`hikari.symmetry.Group`
-    :type point_group: hikari.symmetry.Group
+    :param space_group: Space group of the crystal.
+    :type space_group: hikari.symmetry.Group
     :param input_path: Path to the input .hkl file.
     :type input_path: str
     :param input_format: Format of the .hkl file. For reference see
@@ -53,7 +52,7 @@ def completeness_statistics(a, b, c, al, be, ga,
     p.edit_cell(a=a, b=b, c=c, al=al, be=be, ga=ga)
     p.la = input_wavelength
     p.read(input_path, input_format)
-    p.stats(space_group=point_group)
+    p.stats(space_group=space_group)
 
 
 def dac_completeness_vs_opening_angle(output_path='output.txt',

--- a/hikari/scripts/hkl.py
+++ b/hikari/scripts/hkl.py
@@ -170,7 +170,7 @@ def potency_violin_plot(job_name='violin',
         cplt_dict = dict()
         log = open(log_path, 'w', buffering=1)
         for label, sg in zip(labels, space_groups):
-            p = h.duplicate() if _is_tri_or_hexagonal(sg) else c.duplicate()
+            p = h.copy() if _is_tri_or_hexagonal(sg) else c.copy()
             p.find_equivalents(point_group=sg.reciprocate())
             p.extinct(space_group=sg)
             reflections = list()
@@ -179,7 +179,7 @@ def potency_violin_plot(job_name='violin',
             log.write('total_reflections: ' + str(total_reflections) + '\n')
             log.write('max_r_in_reciprocal: ' + str(max(p.table['r'])) + '\n')
             for vector in vectors:
-                q = p.duplicate()
+                q = p.copy()
                 q.dac(opening_angle=opening_angle, vector=vector)
                 reflections.append(q.table['equiv'].nunique())
                 log.write(str(vector)+': '+str(q.table['equiv'].nunique())+'\n')
@@ -286,12 +286,12 @@ def dac_statistics(a, b, c, al, be, ga,
     p.trim(limit=resolution)
     p.merge(point_group=point_group)
 
-    q = p.duplicate()
+    q = p.copy()
     q.fill(radius=resolution)
     q.dac(opening_angle=opening_angle)
 
     # uncomment and fill this if you have 2 crystals in different orientations
-    # q2 = p.duplicate()
+    # q2 = p.copy()
     # q2.fill(radius=resolution)
     # q2.orientation = np.array(())
     # q2.dac(opening_angle=opening_angle)
@@ -300,7 +300,7 @@ def dac_statistics(a, b, c, al, be, ga,
     q.merge(point_group=point_group)
     q.extinct(space_group=space_group)
 
-    b = p.duplicate()
+    b = p.copy()
     b.fill(radius=resolution)
     b.extinct(space_group=space_group)
     b.merge(point_group=point_group)
@@ -390,7 +390,7 @@ def completeness_statistics_around_axis(a, b, c, al, be, ga,
     cplt = [0] * len(rads)
     p.trim(max(rads))
     for t in toppleds:
-        q = p.duplicate()
+        q = p.copy()
         q.dac(opening_angle=opening_angle, vector=t)
         for cplt_bin, rad in enumerate(rads, start=1):
             q.trim(rad)

--- a/hikari/scripts/potency_map.py
+++ b/hikari/scripts/potency_map.py
@@ -242,7 +242,7 @@ def potency_map(a, b, c, al, be, ga,
         for i, th in enumerate(th_range):
             for j, ph in enumerate(ph_range):
                 v = _translate_angles_to_vector(theta=th, phi=ph)
-                q = p.duplicate()
+                q = p.copy()
                 q.dac(opening_angle=opening_angle, vector=v)
                 hkl_len = q.table['equiv'].nunique()
                 data_dict['th'].append(th)


### PR DESCRIPTION
Method `stats` of `HklFrame` used to return wrong completeness statistics for  merged datasets. After this fix, `stats` not only calculates completeness correctly, but also "I/si(I)". This might fail whenever for some reason the file does not feature `I` or `si`.