### PR TITLE
Fibonacci sphere algorithm

### DIFF
--- a/hikari/utility/math_tools.py
+++ b/hikari/utility/math_tools.py
@@ -78,17 +78,15 @@ def fibonacci_sphere(samples=1, seed=1337):
     """
     random.seed(seed)
     rnd = random.random() * samples
-    points = []
     offset = 2. / samples
     increment = np.pi * (3. - np.sqrt(5.))
-    for i in range(samples):
-        y = ((i * offset) - 1) + (offset / 2)
-        r = np.sqrt(1 - pow(y, 2))
-        phi = ((i + rnd) % samples) * increment
-        x = np.cos(phi) * r
-        z = np.sin(phi) * r
-        points.append(np.array([x, y, z]))
-    return np.vstack(points)
+    i = np.arange(0, samples)
+    y = ((i * offset) - 1) + (offset / 2)
+    r = np.sqrt(1 - pow(y, 2))
+    phi = ((i + rnd) % samples) * increment
+    x = np.cos(phi) * r
+    z = np.sin(phi) * r
+    return np.vstack([x, y, z]).T
 
 
 def euler_rodrigues_matrix(a, b, c, d):

--- a/test/test_utility.py
+++ b/test/test_utility.py
@@ -45,7 +45,7 @@ class TestMathTools(unittest.TestCase):
             (fibonacci_sphere(9)-fibonacci_sphere(9, seed=1337)).max().max(), 0)
         self.assertNotAlmostEqual(
             (fibonacci_sphere(9)-fibonacci_sphere(9, seed=123)).max().max(), 0)
-        self.assertTrue(fibonacci_sphere(9999).sum().sum() < 1.0)
+        self.assertTrue(abs(fibonacci_sphere(99999).sum().sum() < 1.0))
 
 
 class TestOsTools(unittest.TestCase):


### PR DESCRIPTION
Algorithm `hikari.utility.math_tools.fibonacci_sphere` was working surprisingly slow. Generating sphere of 1 million elements required over 5 seconds on my working setup due to inefficient looping. The function has been vectorised using numpy, resulting in a 50x faster execution time while yielding exactly identical output. As a result, `potency_map` script might work a tad faster.   