### PR TITLE
Angular explorer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,8 +30,8 @@ release = '0.1.5'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage',
-]
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -47,7 +47,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'bizstyle'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/hikari.scripts.rst
+++ b/docs/hikari.scripts.rst
@@ -4,6 +4,14 @@ hikari.scripts package
 Submodules
 ----------
 
+hikari.scripts.angular\_explorer module
+---------------------------------------
+
+.. automodule:: hikari.scripts.angular_explorer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 hikari.scripts.fcf module
 -------------------------
 

--- a/docs/hikari.utility.rst
+++ b/docs/hikari.utility.rst
@@ -4,10 +4,26 @@ hikari.utility package
 Submodules
 ----------
 
+hikari.utility.artists module
+-----------------------------
+
+.. automodule:: hikari.utility.artists
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 hikari.utility.chem\_tools module
 ---------------------------------
 
 .. automodule:: hikari.utility.chem_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+hikari.utility.interval module
+------------------------------
+
+.. automodule:: hikari.utility.interval
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,17 @@
 Welcome to hikari's documentation!
 ==================================
 
-.. automodule::hikari
-   :members:
+hikari is a simple Python3.6+ package for manipulating basic crystallographic
+files: mainly .hkl, but also .res, .cif and, by extension, .fcf.
+This documentation is generated automatically based on docstrings.
+If you are further interested in the package,
+please visit `https://github.com/Baharis/hikari`.
 
 .. toctree::
-   :maxdepth: 4
-   :caption: Contents:
+   :maxdepth: 2
+   :caption: Context
 
-
+   modules
 
 Indices and tables
 ==================

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -5,3 +5,4 @@ hikari
    :maxdepth: 4
 
    hikari
+   setup

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,0 +1,7 @@
+setup module
+============
+
+.. automodule:: setup
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -448,8 +448,8 @@ class HklFrame(BaseFrame):
         Sample/DAC orientation can be supplied either via specifying crystal
         orientation in :class:`hikari.dataframes.BaseFrame`, in
         :attr:`orientation` or providing a xyz\* *vector* perpendicular to the
-        dac-accessible disc. For further details refer to *Tchoń & Makal, IUCrJ
-        8, 1006-1017 (2021)* `https://doi.org/10.1107/s2052252521009532`_.
+        dac-accessible disc. For further details refer to `*Tchoń & Makal, IUCrJ
+        8, 1006-1017 (2021)* <https://doi.org/10.1107/s2052252521009532>`_.
 
         :param opening_angle: DAC single opening angle in degrees, default 35.0.
         :type opening_angle: float
@@ -597,7 +597,8 @@ class HklFrame(BaseFrame):
         :type bins: int
         :param space_group: Group used to calculate equivalence and extinctions.
         :type space_group: hikari.symmetry.Group
-        :returns
+        :return: String containing table with stats as a function of resolution
+        :rtype: str
         """
 
         point_group = space_group.reciprocate()

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -1285,4 +1285,3 @@ class HklToResConverter:
 
     # TODO wrap table/data in getter/setter and make it automatically place,
     # TODO refresh, set keys etc.
-    # TODO import problems - PG / SG must be imported first???

--- a/hikari/resources/gnuplot_angular_heatmap_template.gnu
+++ b/hikari/resources/gnuplot_angular_heatmap_template.gnu
@@ -6,8 +6,8 @@ set output '{job_name}_gnu.png'
 
 # load variables from python
 make_histogram = {histogram}
-min_heat = {cplt_min}
-max_heat = {cplt_max}
+min_heat = 100. * {cplt_min}
+max_heat = 100. * {cplt_max}
 min_ph = {min_ph}
 max_ph = {max_ph}
 min_th = {min_th}

--- a/hikari/scripts/__init__.py
+++ b/hikari/scripts/__init__.py
@@ -14,7 +14,6 @@ Users are cordially invited to propose their own scripts or script ideas.
 """
 from .hkl_potency import potency_map, potency_vs_dac_opening_angle, \
     potency_violin_plot, dac_potency_around_axis
-from .hkl_completeness import completeness_statistics
-from .hkl_completeness import dac_statistics
-from .hkl_completeness import simulate_dac
+from .hkl_completeness import completeness_statistics, dac_statistics, \
+    simulate_dac
 from .r1_map import r1_map

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -72,7 +72,11 @@ class AngularPropertyExplorer:
 
     def __init__(self):
         self._path = ''
-        self.sg = Group()
+        self._sg = Group()
+        self._pg = Group()
+        self._lg = Group()
+        self._th_limits = Interval(0, 0)
+        self._ph_limits = Interval(0, 0)
         self.axis = ''
         self.hkl_frame = HklFrame()
         self.opening_angle = 0.0
@@ -169,12 +173,12 @@ class AngularPropertyExplorer:
     @property
     def th_limits(self):
         """Interval range of polar angle where property will be calculated"""
-        return self.POLAR_LIMIT_DICT[self.sg.system]
+        return self._th_limits
 
     @property
     def ph_limits(self):
         """Interval range of azimuth angle where property will be calculated"""
-        return self.AZIMUTH_LIMIT_DICT[self.sg.system]
+        return self._ph_limits
 
     def draw_matplotlib_map(self):
         ma = MatplotlibAngularHeatmapArtist()
@@ -222,12 +226,26 @@ class AngularPropertyExplorer:
         self._path = str(Path().joinpath(dir_, stem))
 
     @property
+    def sg(self):
+        return self._sg
+
+    @sg.setter
+    def sg(self, value):
+        _pg = value.reciprocate()
+        _sg_system = value.system
+        self._sg = value
+        self._pg = _pg
+        self._lg = _pg.lauefy()
+        self._th_limits = self.POLAR_LIMIT_DICT[_sg_system]
+        self._ph_limits = self.AZIMUTH_LIMIT_DICT[_sg_system]
+
+    @property
     def pg(self):
-        return self.sg.reciprocate()
+        return self._pg
 
     @property
     def lg(self):
-        return self.pg.lauefy()
+        return self._lg
 
     @property
     def focus(self):

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -52,46 +52,35 @@ class AngularPropertyExplorer:
 
     HKL_IS_READ_NOT_GENERATED = True
 
+    POLAR_LIMIT_DICT = {Group.System.triclinic: Interval(0, 180),
+                        Group.System.monoclinic: Interval(0, 180),
+                        Group.System.orthorhombic: Interval(0, 90),
+                        Group.System.tetragonal: Interval(0, 90),
+                        Group.System.trigonal: Interval(0, 90),
+                        Group.System.hexagonal: Interval(0, 90),
+                        Group.System.cubic: Interval(0, 90)}
+
+    AZIMUTH_LIMIT_DICT = {Group.System.triclinic: Interval(-45, 135),
+                          Group.System.monoclinic: Interval(0, 90),
+                          Group.System.orthorhombic: Interval(0, 90),
+                          Group.System.tetragonal: Interval(0, 90),
+                          Group.System.trigonal: Interval(0, 120),
+                          Group.System.hexagonal: Interval(0, 120),
+                          Group.System.cubic: Interval(0, 90)}
+
     def __init__(self):
-        self.gnu_path = ''
-        self.gnu_png_path = ''
-        self.his_path = ''
-        self.hkl_path = ''
-        self.lst_path = ''
-        self.mpl_png_path = ''
-        self.mesh_path = ''
+        self._path = ''
         self.sg = Group()
-        self.pg = Group()
-        self.lg = Group()
+        self.axis = ''
         self.heat_limits = Interval(0, 1)
         self.hkl_frame = HklFrame()
         self.oa = 0.0
         self.orientation = None
         self.resolution = 1.2
-        self.th_limits = Interval(0, 0)
-        self.ph_limits = Interval(0, 0)
-        self.ax = ''
+        self.axis = ''
         self.fix_scale = False
         self.histogram = False
         self.output_quality = 1
-
-    def set_path(self, path):
-        """
-        Set the path to the workspace. The directory and stem must be common
-        for all input and output files, the extensions are set automatically.
-        :param path: A path to any file with correct stem in working directory.
-        :type path: str
-        """
-        png_path = Path(make_abspath(path))
-        dir_, stem, ext = png_path.parent, png_path.stem, png_path.suffix
-        base_path = str(Path().joinpath(dir_, stem))
-        self.gnu_path = base_path + self.GNUPLOT_INPUT_EXTENSION
-        self.gnu_png_path = base_path + self.GNUPLOT_OUTPUT_EXTENSION
-        self.his_path = base_path + self.HISTOGRAM_EXTENSION
-        self.hkl_path = base_path + self.HKL_EXTENSION
-        self.lst_path = base_path + self.LISTING_EXTENSION
-        self.mpl_png_path = base_path + self.MATPLOTLIB_EXTENSION
-        self.mesh_path = base_path + self.MESH_EXTENSION
 
     def set_experimental(self, opening_angle, orientation, resolution):
         self.oa = opening_angle
@@ -100,10 +89,9 @@ class AngularPropertyExplorer:
 
     def set_hkl_frame(self, a, b, c, al, be, ga, space_group, wavelength, axis):
         self.sg = SG[space_group]
-        self.pg = self.sg.reciprocate()
-        self.lg = self.pg.lauefy()
         self.hkl_frame.edit_cell(a=a, b=b, c=c, al=al, be=be, ga=ga)
         self.hkl_frame.la = wavelength
+        self.axis = axis
         if self.HKL_IS_READ_NOT_GENERATED:
             self._read_hkl_frame(hkl_format='shelx_4')
         else:
@@ -112,19 +100,15 @@ class AngularPropertyExplorer:
         total_reflections = self.hkl_frame.table['equiv'].nunique()
         if total_reflections == 0:
             raise KeyError('Specified part of reciprocal space has zero nodes')
-        self._determine_theta_and_phi_limits()
 
-    def set_options(self, ax, fix_scale, histogram, output_quality):
-        self.ax = ''
-        self.fix_scale = False
-        self.histogram = False
+    def set_options(self, path, fix_scale, histogram, output_quality):
+        self.path = path
+        self.fix_scale = fix_scale
+        self.histogram = histogram
         self.output_quality = output_quality
 
     def explore(self):
-        th_range = self.th_limits.arange(step=self.angle_res)
-        ph_range = self.ph_limits.arange(step=self.angle_res)
-        th_mesh, ph_mesh = self.th_limits.mesh_with(self.ph_limits,
-                                                    step=self.angle_res)
+
         data_dict = {'th': [], 'ph': [], 'cplt': [], 'r1': [], 'weight': []}
 
         self.heat_limits = Interval(
@@ -155,28 +139,20 @@ class AngularPropertyExplorer:
     def _read_hkl_frame(self, hkl_format):
         """Read reflections of hkl which will be cut in further steps"""
         f = self.hkl_frame
-        f.read(hkl_path=self.hkl_path, hkl_format=hkl_format)
+        f.read(hkl_path=self.path + self.HKL_EXTENSION, hkl_format=hkl_format)
         f.trim(limit=min(f.r_lim, self.resolution))
         f.find_equivalents(point_group=self.lg)
         return f
 
-    def _determine_theta_and_phi_limits(self):
-        """Define range of coordinates where potency map will be calculated."""
-        if self.sg.system in {Group.System.triclinic}:
-            self.th_limits = Interval(0, 180)
-            self.limits = Interval(-45, 135)
-        elif self.sg.system in {Group.System.monoclinic}:
-            self.th_limits = Interval(0, 180)
-            self.ph_limits = Interval(0, 90)
-        elif self.sg.system in {Group.System.orthorhombic,
-                                Group.System.tetragonal, Group.System.cubic}:
-            self.th_limits = Interval(0, 90)
-            self.ph_limits = Interval(0, 90)
-        elif self.sg.system in {Group.System.trigonal, Group.System.hexagonal}:
-            self.th_limits = Interval(0, 90)
-            self.ph_limits = Interval(0, 120)
-        else:
-            raise ValueError('Unknown crystal system (trigonal not supported)')
+    @property
+    def th_limits(self):
+        """Interval range of polar angle where property will be calculated"""
+        return self.POLAR_LIMIT_DICT[self.sg.system]
+
+    @property
+    def ph_limits(self):
+        """Interval range of azimuth angle where property will be calculated"""
+        return self.AZIMUTH_LIMIT_DICT[self.sg.system]
 
     def _draw_matplotlib_map(self):
         ma = MatplotlibAngularHeatmapArtist()
@@ -188,7 +164,7 @@ class AngularPropertyExplorer:
         ma.heat_palette = self.axis
         ma.polar_limits = self.th_limits
         ma.azimuth_limits = self.ph_limits
-        ma.plot(self.mpl_png_path)
+        ma.plot(self.path + self.MATPLOTLIB_EXTENSION)
 
     def _draw_gnuplot_map(self):
         ga = GnuplotAngularHeatmapArtist()
@@ -201,7 +177,7 @@ class AngularPropertyExplorer:
         ga.histogram = self.histogram
         ga.polar_limits = self.th_limits
         ga.azimuth_limits = self.ph_limits
-        ga.plot(self.gnu_png_path)
+        ga.plot(self.path + self.GNUPLOT_OUTPUT_EXTENSION)
 
     @property
     def angle_res(self):
@@ -210,19 +186,69 @@ class AngularPropertyExplorer:
         return {1: 15, 2: 10, 3: 5, 4: 2, 5: 1}[self.output_quality]
 
     @property
+    def path(self):
+        """
+        Provides path = directory + stem to the workspace. They are common to
+        all input and output files, the extensions are specified as class var.
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        abs_path = Path(make_abspath(path))
+        dir_, stem, ext = abs_path.parent, abs_path.stem, abs_path.suffix
+        self._path = str(Path().joinpath(dir_, stem))
+
+    @property
+    def pg(self):
+        return self.sg.reciprocate()
+
+    @property
+    def lg(self):
+        return self.pg.lauefy()
+
+    @property
     def focus(self):
         if self.orientation is None:
             return []
         else:
             _focus = []
+            a = lin.inv(self.orientation) @ np.array((1, 0, 0))
             for op in self.lg.operations:
-                v = self.hkl_frame.A_r.T @ op.tf @ lin.inv(self.orientation) \
-                    @ np.array((1, 0, 0))
-                c = cart2sph(*v)
-                if np.rad2deg(c[1]) in self.th_limits and \
-                        np.rad2deg(c[2]) in self.ph_limits:
+                v = self.hkl_frame.A_r.T @ op.tf @ a
+                c = np.rad2deg(cart2sph(*v))
+                if c[1] in self.th_limits and c[2] in self.ph_limits:
                     _focus.append(v / lin.norm(v))
         return _focus
+
+    @property
+    def th_range(self):
+        return self.th_limits.arange(step=self.angle_res)
+
+    @property
+    def ph_range(self):
+        return self.ph_limits.arange(step=self.angle_res)
+
+    @property
+    def th_mesh(self):
+        return self.th_limits.mesh_with(self.ph_limits, step=self.angle_res)[0]
+
+    @property
+    def ph_mesh(self):
+        return self.th_limits.mesh_with(self.ph_limits, step=self.angle_res)[1]
+
+    def orientation_weight(self, th, ph):
+        """Calculate how much each point should contribute to distribution"""
+        def sphere_cutout_area(th1, th2, ph_span):
+            """Calculate sphere area in specified ph and th degree range.
+            For exact math, see articles about spherical cap and sector."""
+            return np.deg2rad(abs(ph_span)) * \
+                   abs(np.cos(np.deg2rad(th1)) - np.cos(np.deg2rad(th2)))
+        th_max = min(th + self.angle_res / 2., self.th_limits[1])
+        th_min = max(th - self.angle_res / 2., self.th_limits[0])
+        ph_max = min(ph + self.angle_res / 2., self.ph_limits[1])
+        ph_min = max(ph - self.angle_res / 2., self.ph_limits[0])
+        return sphere_cutout_area(th_min, th_max, ph_max-ph_min)
 
 
 class AngularPotencyExplorer(AngularPropertyExplorer):

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -75,7 +75,6 @@ class AngularPropertyExplorer:
         self._path = ''
         self.sg = Group()
         self.axis = ''
-        self.heat_limits = Interval(0, 1)
         self.hkl_frame = HklFrame()
         self.oa = 0.0
         self.orientation = None
@@ -111,13 +110,13 @@ class AngularPropertyExplorer:
         self.histogram = histogram
         self.output_quality = output_quality
 
+    @abc.abstractmethod
     def explore(self):
-
-        data_dict = {'th': [], 'ph': [], 'cplt': [], 'r1': [], 'weight': []}
-
-        self.heat_limits = Interval(
-            0 if self.fix_scale else min(data_dict['heat']),
-            1 if self.fix_scale else max(data_dict['heat']))
+        """
+        Main interface method which, apart from the setters, is run within
+        the script itself and generates data and figures using class methods
+        """
+        pass
 
     @property
     def prop_limits(self):
@@ -174,7 +173,7 @@ class AngularPropertyExplorer:
         ma.y_axis = self.hkl_frame.b_w / lin.norm(self.hkl_frame.b_w)
         ma.z_axis = self.hkl_frame.c_w / lin.norm(self.hkl_frame.c_w)
         ma.focus = self.focus
-        ma.heat_limits = self.heat_limits
+        ma.heat_limits = self.prop_limits
         ma.heat_palette = self.axis
         ma.polar_limits = self.th_limits
         ma.azimuth_limits = self.ph_limits
@@ -186,7 +185,7 @@ class AngularPropertyExplorer:
         ga.y_axis = self.hkl_frame.b_w / lin.norm(self.hkl_frame.b_w)
         ga.z_axis = self.hkl_frame.c_w / lin.norm(self.hkl_frame.c_w)
         ga.focus = self.focus
-        ga.heat_limits = self.heat_limits
+        ga.heat_limits = self.prop_limits
         ga.heat_palette = self.axis
         ga.histogram = self.histogram
         ga.polar_limits = self.th_limits

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -1,0 +1,16 @@
+"""This file contains tools for making property maps visualised on sphere"""
+
+
+class AngularPropertyExplorerFactory:
+    """Factory method for angular prop. explorers based on realpython thread."""
+    def __init__(self):
+        self._explorers = {}
+
+    def register_explorer(self, prop, explorer):
+        self._explorers[prop] = explorer
+
+    def create(self, prop, **kwargs):
+        explorer = self._explorers.get(prop)
+        if not explorer:
+            raise ValueError(f'Explorer for {prop} has not been registered!')
+        return explorer(**kwargs)

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -1,6 +1,7 @@
 """This file contains tools for making property maps visualised on sphere"""
 
 import abc
+import numbers
 from pathlib import Path
 
 import numpy as np
@@ -42,10 +43,9 @@ class AngularPropertyExplorer:
     - explore
     """
 
-    hkl_is_read_not_generated = True
-    property_name = 'UNDEFINED'
-    property_theoretical_minimum = 0
-    property_theoretical_maximum = 1
+    hkl_is_read_not_generated: bool
+    property_name: str
+    property_theoretical_limits: Interval
 
     GNUPLOT_INPUT_EXTENSION = '.gnu'
     GNUPLOT_OUTPUT_EXTENSION = '.pnG'
@@ -121,12 +121,11 @@ class AngularPropertyExplorer:
     @property
     def prop_limits(self):
         if not self.fix_scale and self.data_dict[self.property_name]:
-            lower_property_limit = min(self.data_dict[self.property_name])
-            upper_property_limit = max(self.data_dict[self.property_name])
+            _prop_limits = Interval(min(self.data_dict[self.property_name]),
+                                    max(self.data_dict[self.property_name]))
         else:
-            lower_property_limit = self.property_theoretical_minimum
-            upper_property_limit = self.property_theoretical_maximum
-        return Interval(lower_property_limit, upper_property_limit)
+            _prop_limits = self.property_theoretical_limits
+        return _prop_limits
 
     def _make_hkl_frame(self):
         """Make ball or axis of hkl which will be cut in further steps"""
@@ -267,13 +266,17 @@ class AngularPropertyExplorer:
 class AngularPotencyExplorer(AngularPropertyExplorer):
     hkl_is_read_not_generated = False
     property_name = 'cplt'
-    property_theoretical_minimum = 0
-    property_theoretical_maximum = 1
+    property_theoretical_limits = Interval(0, 1)
+
+    def explore(self):
+        pass
 
 
 class AngularR1Explorer(AngularPropertyExplorer):
+
     hkl_is_read_not_generated = True
     property_name = 'r1'
-    property_theoretical_minimum = 0
-    property_theoretical_maximum = 1
+    property_theoretical_limits = Interval(0, 1)
 
+    def explore(self):
+        pass

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -1,8 +1,21 @@
 """This file contains tools for making property maps visualised on sphere"""
 
+import abc
+from pathlib import Path
+
+import numpy as np
+from numpy import linalg as lin
+
+from hikari.dataframes import HklFrame
+from hikari.symmetry import SG, Group
+from hikari.utility import make_abspath, weighted_quantile, \
+    fibonacci_sphere, rotation_around, sph2cart, cart2sph, Interval
+from hikari.utility import GnuplotAngularHeatmapArtist, \
+    MatplotlibAngularHeatmapArtist
+
 
 class AngularPropertyExplorerFactory:
-    """Factory method for angular prop. explorers based on realpython thread."""
+    """A factory method for creating angular property explorers."""
     def __init__(self):
         self._explorers = {}
 
@@ -14,3 +27,209 @@ class AngularPropertyExplorerFactory:
         if not explorer:
             raise ValueError(f'Explorer for {prop} has not been registered!')
         return explorer(**kwargs)
+
+
+class AngularPropertyExplorer:
+    """
+    An abstract base class for objects handling analysing parameters as
+    a function of crystal orientation in a Diamond Anvil Cell.
+    In order to generate a map of desired property,
+    the following methods must be executed in order:
+
+    - set_path
+    - set_sample
+    - set_output
+    - explore
+    """
+
+    GNUPLOT_INPUT_EXTENSION = '.gnu'
+    GNUPLOT_OUTPUT_EXTENSION = '.pnG'
+    HISTOGRAM_EXTENSION = '.his'
+    HKL_EXTENSION = '.hkl'
+    LISTING_EXTENSION = '.lst'
+    MATPLOTLIB_EXTENSION = '.png'
+    MESH_EXTENSION = '.dat'
+
+    HKL_IS_READ_NOT_GENERATED = True
+
+    def __init__(self):
+        self.gnu_path = ''
+        self.gnu_png_path = ''
+        self.his_path = ''
+        self.hkl_path = ''
+        self.lst_path = ''
+        self.mpl_png_path = ''
+        self.mesh_path = ''
+        self.sg = Group()
+        self.pg = Group()
+        self.lg = Group()
+        self.heat_limits = Interval(0, 1)
+        self.hkl_frame = HklFrame()
+        self.oa = 0.0
+        self.orientation = None
+        self.resolution = 1.2
+        self.th_limits = Interval(0, 0)
+        self.ph_limits = Interval(0, 0)
+        self.ax = ''
+        self.fix_scale = False
+        self.histogram = False
+        self.output_quality = 1
+
+    def set_path(self, path):
+        """
+        Set the path to the workspace. The directory and stem must be common
+        for all input and output files, the extensions are set automatically.
+        :param path: A path to any file with correct stem in working directory.
+        :type path: str
+        """
+        png_path = Path(make_abspath(path))
+        dir_, stem, ext = png_path.parent, png_path.stem, png_path.suffix
+        base_path = str(Path().joinpath(dir_, stem))
+        self.gnu_path = base_path + self.GNUPLOT_INPUT_EXTENSION
+        self.gnu_png_path = base_path + self.GNUPLOT_OUTPUT_EXTENSION
+        self.his_path = base_path + self.HISTOGRAM_EXTENSION
+        self.hkl_path = base_path + self.HKL_EXTENSION
+        self.lst_path = base_path + self.LISTING_EXTENSION
+        self.mpl_png_path = base_path + self.MATPLOTLIB_EXTENSION
+        self.mesh_path = base_path + self.MESH_EXTENSION
+
+    def set_experimental(self, opening_angle, orientation, resolution):
+        self.oa = opening_angle
+        self.orientation = orientation
+        self.resolution = resolution
+
+    def set_hkl_frame(self, a, b, c, al, be, ga, space_group, wavelength, axis):
+        self.sg = SG[space_group]
+        self.pg = self.sg.reciprocate()
+        self.lg = self.pg.lauefy()
+        self.hkl_frame.edit_cell(a=a, b=b, c=c, al=al, be=be, ga=ga)
+        self.hkl_frame.la = wavelength
+        if self.HKL_IS_READ_NOT_GENERATED:
+            self._read_hkl_frame(hkl_format='shelx_4')
+        else:
+            self._make_hkl_frame(ax=axis)
+        self.hkl_frame.find_equivalents(point_group=self.pg)
+        total_reflections = self.hkl_frame.table['equiv'].nunique()
+        if total_reflections == 0:
+            raise KeyError('Specified part of reciprocal space has zero nodes')
+        self._determine_theta_and_phi_limits()
+
+    def set_options(self, ax, fix_scale, histogram, output_quality):
+        self.ax = ''
+        self.fix_scale = False
+        self.histogram = False
+        self.output_quality = output_quality
+
+    def explore(self):
+        th_range = self.th_limits.arange(step=self.angle_res)
+        ph_range = self.ph_limits.arange(step=self.angle_res)
+        th_mesh, ph_mesh = self.th_limits.mesh_with(self.ph_limits,
+                                                    step=self.angle_res)
+        data_dict = {'th': [], 'ph': [], 'cplt': [], 'r1': [], 'weight': []}
+
+        self.heat_limits = Interval(
+            0 if self.fix_scale else min(data_dict['heat']),
+            1 if self.fix_scale else max(data_dict['heat']))
+
+    def _make_hkl_frame(self, ax):
+        """Make ball or axis of hkl which will be cut in further steps"""
+        f = self.hkl_frame
+        f.fill(radius=min(self.hkl_frame.r_lim, self.resolution))
+        if ax in {'x'}:
+            f.table = f.table.loc[f.table['k'].eq(0) & f.table['l'].eq(0)]
+        elif ax in {'y'}:
+            f.table = f.table.loc[f.table['h'].eq(0) & f.table['l'].eq(0)]
+        elif ax in {'z'}:
+            f.table = f.table.loc[f.table['h'].eq(0) & f.table['k'].eq(0)]
+        elif ax in {'xy'}:
+            f.table = f.table.loc[f.table['l'].eq(0)]
+        elif ax in {'xz'}:
+            f.table = f.table.loc[f.table['k'].eq(0)]
+        elif ax in {'yz'}:
+            f.table = f.table.loc[f.table['h'].eq(0)]
+        if ax in {'x', 'y', 'z', 'xy', 'xz', 'yz'}:
+            f.transform([o.tf for o in self.pg.operations])
+        f.extinct(self.sg)
+        return f
+
+    def _read_hkl_frame(self, hkl_format):
+        """Read reflections of hkl which will be cut in further steps"""
+        f = self.hkl_frame
+        f.read(hkl_path=self.hkl_path, hkl_format=hkl_format)
+        f.trim(limit=min(f.r_lim, self.resolution))
+        f.find_equivalents(point_group=self.lg)
+        return f
+
+    def _determine_theta_and_phi_limits(self):
+        """Define range of coordinates where potency map will be calculated."""
+        if self.sg.system in {Group.System.triclinic}:
+            self.th_limits = Interval(0, 180)
+            self.limits = Interval(-45, 135)
+        elif self.sg.system in {Group.System.monoclinic}:
+            self.th_limits = Interval(0, 180)
+            self.ph_limits = Interval(0, 90)
+        elif self.sg.system in {Group.System.orthorhombic,
+                                Group.System.tetragonal, Group.System.cubic}:
+            self.th_limits = Interval(0, 90)
+            self.ph_limits = Interval(0, 90)
+        elif self.sg.system in {Group.System.trigonal, Group.System.hexagonal}:
+            self.th_limits = Interval(0, 90)
+            self.ph_limits = Interval(0, 120)
+        else:
+            raise ValueError('Unknown crystal system (trigonal not supported)')
+
+    def _draw_matplotlib_map(self):
+        ma = MatplotlibAngularHeatmapArtist()
+        ma.x_axis = self.hkl_frame.a_w / lin.norm(self.hkl_frame.a_w)
+        ma.y_axis = self.hkl_frame.b_w / lin.norm(self.hkl_frame.b_w)
+        ma.z_axis = self.hkl_frame.c_w / lin.norm(self.hkl_frame.c_w)
+        ma.focus = self.focus
+        ma.heat_limits = self.heat_limits
+        ma.heat_palette = self.axis
+        ma.polar_limits = self.th_limits
+        ma.azimuth_limits = self.ph_limits
+        ma.plot(self.mpl_png_path)
+
+    def _draw_gnuplot_map(self):
+        ga = GnuplotAngularHeatmapArtist()
+        ga.x_axis = self.hkl_frame.a_w / lin.norm(self.hkl_frame.a_w)
+        ga.y_axis = self.hkl_frame.b_w / lin.norm(self.hkl_frame.b_w)
+        ga.z_axis = self.hkl_frame.c_w / lin.norm(self.hkl_frame.c_w)
+        ga.focus = self.focus
+        ga.heat_limits = self.heat_limits
+        ga.heat_palette = self.axis
+        ga.histogram = self.histogram
+        ga.polar_limits = self.th_limits
+        ga.azimuth_limits = self.ph_limits
+        ga.plot(self.gnu_png_path)
+
+    @property
+    def angle_res(self):
+        if self.output_quality not in {1, 2, 3, 4, 5}:
+            raise KeyError('output_quality should be 1, 2, 3, 4 or 5')
+        return {1: 15, 2: 10, 3: 5, 4: 2, 5: 1}[self.output_quality]
+
+    @property
+    def focus(self):
+        if self.orientation is None:
+            return []
+        else:
+            _focus = []
+            for op in self.lg.operations:
+                v = self.hkl_frame.A_r.T @ op.tf @ lin.inv(self.orientation) \
+                    @ np.array((1, 0, 0))
+                c = cart2sph(*v)
+                if np.rad2deg(c[1]) in self.th_limits and \
+                        np.rad2deg(c[2]) in self.ph_limits:
+                    _focus.append(v / lin.norm(v))
+        return _focus
+
+
+class AngularPotencyExplorer(AngularPropertyExplorer):
+    HKL_IS_READ_NOT_GENERATED = False
+
+
+class AngularR1Explorer(AngularPropertyExplorer):
+    HKL_IS_READ_NOT_GENERATED = True
+
+

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -93,7 +93,8 @@ class AngularPropertyExplorer:
                opening_angle, orientation, resolution,
                path, fix_scale, histogram, output_quality):
         self.opening_angle = opening_angle
-        self.orientation = orientation
+        self.orientation = None if orientation is None \
+            else np.array(orientation)
         self.resolution = resolution
         self.path = path
         self.fix_scale = fix_scale
@@ -243,11 +244,14 @@ class AngularPropertyExplorer:
 
     @property
     def focus(self):
-        if self.orientation is None:
-            return []
-        else:
-            _focus = []
-            a = lin.inv(self.orientation) @ np.array((1, 0, 0))
+        _focus = []
+        if self.orientation is not None:
+            if len(self.orientation.shape) == 1:
+                a = self.orientation
+            elif len(self.orientation.shape) == 2:
+                a = lin.inv(self.orientation) @ np.array((1, 0, 0))
+            else:
+                raise ValueError(f'Unknown orientation: {self.orientation}')
             for op in self.lg.operations:
                 v = self.hkl_frame.A_r.T @ op.tf @ a
                 c = np.rad2deg(cart2sph(*v))

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -86,8 +86,8 @@ class AngularPropertyExplorer:
         self.fix_scale = False
         self.histogram = False
         self.output_quality = 1
-        self.data_dict = {'th': [], 'ph': [], 'cplt': [], 'reflns': [],
-                          'r1': [], 'weight': []}
+        self.data_dict = {'th': [], 'ph': [], 'potency': [], 'reflns': [],
+                          'R1': [], 'weight': []}
 
     def set_up(self, a, b, c, al, be, ga, space_group, wavelength, axis,
                opening_angle, orientation, resolution,
@@ -306,7 +306,7 @@ class AngularPropertyExplorer:
 
         avg_p = np.average(self.data_dict[self.property_name],
                            weights=self.data_dict['weight'])
-        q1, q2, q3 = weighted_quantile(values=self.data_dict['cplt'],
+        q1, q2, q3 = weighted_quantile(self.data_dict[self.property_name],
                                        quantiles=[0.25, 0.50, 0.75],
                                        weights=self.data_dict['weight'])
 
@@ -322,16 +322,16 @@ class AngularPropertyExplorer:
 
 class AngularPotencyExplorer(AngularPropertyExplorer):
     hkl_is_read_not_generated = False
-    property_name = 'cplt'
+    property_name = 'potency'
     property_theoretical_limits = Interval(0, 1)
 
     def explore(self):
         dat_path = self.path + self.MESH_EXTENSION
         lst_path = self.path + self.LISTING_EXTENSION
 
-        cplt_mesh = np.zeros_like(self.th_mesh, dtype=float)
+        potency_mesh = np.zeros_like(self.th_mesh, dtype=float)
         lst = open(lst_path, 'w+')
-        lst.write('#     th      ph    cplt  reflns\n')
+        lst.write('#     th      ph potency  reflns\n')
         vectors = sph2cart(r=np.ones_like(self.th_comb),
                            p=np.deg2rad(self.th_comb),
                            a=np.deg2rad(self.ph_comb)).T
@@ -346,15 +346,15 @@ class AngularPotencyExplorer(AngularPropertyExplorer):
                 potency = unique / total_unique
                 self.data_dict['th'].append(th)
                 self.data_dict['ph'].append(ph)
-                self.data_dict['cplt'].append(potency)
+                self.data_dict['potency'].append(potency)
                 self.data_dict['reflns'].append(unique)
                 self.data_dict['weight'].append(weight)
                 lst.write(f'{th:8.0f}{ph:8.0f}{potency:8.5f}{unique:8d}\n')
-                cplt_mesh[j][i] = potency
+                potency_mesh[j][i] = potency
             lst.write('\n')
 
         # noinspection PyTypeChecker
-        np.savetxt(dat_path, cplt_mesh)
+        np.savetxt(dat_path, potency_mesh)
         lst.write(self.descriptive_statistics_string)
         lst.close()
 
@@ -362,7 +362,7 @@ class AngularPotencyExplorer(AngularPropertyExplorer):
 class AngularR1Explorer(AngularPropertyExplorer):
 
     hkl_is_read_not_generated = True
-    property_name = 'r1'
+    property_name = 'R1'
     property_theoretical_limits = Interval(0, 1)
 
     def explore(self):
@@ -372,7 +372,7 @@ class AngularR1Explorer(AngularPropertyExplorer):
 
         r1_mesh = np.zeros_like(self.th_mesh, dtype=float)
         lst = open(lst_path, 'w+')
-        lst.write('#     th      ph    cplt  reflns\n')
+        lst.write('#     th      ph      R1  reflns\n')
 
         weights = self.orientation_weights(th=self.th_comb, ph=self.ph_comb)
         total_unique = self.hkl_frame.table['equiv'].nunique()
@@ -397,11 +397,11 @@ class AngularR1Explorer(AngularPropertyExplorer):
                 potency = unique / total_unique
                 self.data_dict['th'].append(th)
                 self.data_dict['ph'].append(ph)
-                self.data_dict['cplt'].append(potency)
-                self.data_dict['r1'].append(r1)
+                self.data_dict['potency'].append(potency)
+                self.data_dict['R1'].append(r1)
                 self.data_dict['weight'].append(weight)
                 lst.write(f'{th:8.0f}{ph:8.0f}{r1:8.5}{potency:8.5f}\n')
-                r1_mesh[i][j] = r1
+                r1_mesh[j][i] = r1
             lst.write('\n')
 
         # noinspection PyTypeChecker

--- a/hikari/scripts/angular_explorer.py
+++ b/hikari/scripts/angular_explorer.py
@@ -89,12 +89,16 @@ class AngularPropertyExplorer:
         self.data_dict = {'th': [], 'ph': [], 'cplt': [], 'reflns': [],
                           'r1': [], 'weight': []}
 
-    def set_experimental(self, opening_angle, orientation, resolution):
+    def set_up(self, a, b, c, al, be, ga, space_group, wavelength, axis,
+               opening_angle, orientation, resolution,
+               path, fix_scale, histogram, output_quality):
         self.opening_angle = opening_angle
         self.orientation = orientation
         self.resolution = resolution
-
-    def set_hkl_frame(self, a, b, c, al, be, ga, space_group, wavelength, axis):
+        self.path = path
+        self.fix_scale = fix_scale
+        self.histogram = histogram
+        self.output_quality = output_quality
         self.sg = SG[space_group]
         self.hkl_frame.edit_cell(a=a, b=b, c=c, al=al, be=be, ga=ga)
         self.hkl_frame.la = wavelength
@@ -107,12 +111,6 @@ class AngularPropertyExplorer:
         total_unique = self.hkl_frame.table['equiv'].nunique()
         if total_unique == 0:
             raise KeyError('Specified part of reciprocal space has zero nodes')
-
-    def set_options(self, path, fix_scale, histogram, output_quality):
-        self.path = path
-        self.fix_scale = fix_scale
-        self.histogram = histogram
-        self.output_quality = output_quality
 
     @abc.abstractmethod
     def explore(self):
@@ -414,3 +412,11 @@ class AngularR1Explorer(AngularPropertyExplorer):
         np.savetxt(dat_path, r1_mesh)
         lst.write(self.descriptive_statistics_string)
         lst.close()
+
+
+angular_property_explorer_factory = AngularPropertyExplorerFactory()
+angular_property_explorer_factory.register_explorer(
+    prop='potency', explorer=AngularPotencyExplorer)
+angular_property_explorer_factory.register_explorer(
+    prop='r1', explorer=AngularR1Explorer)
+

--- a/hikari/scripts/fcf.py
+++ b/hikari/scripts/fcf.py
@@ -191,6 +191,7 @@ def fcf_descriptors(input_path='shelx.fcf', input_format='shelx_fcf'):
 def calculate_sample_form_factors(a, b, c, al, be, ga, space_group, res_path):
     """
     Estimate and print selected IAM XRD form factors for given crystal structure
+
     :param a: Unit cell parameter *a* in Angstrom.
     :type a: float
     :param b: Unit cell parameter *b* in Angstrom.

--- a/hikari/scripts/hkl_completeness.py
+++ b/hikari/scripts/hkl_completeness.py
@@ -38,8 +38,8 @@ def completeness_statistics(a, b, c, al, be, ga,
     :type space_group: str or int
     :param input_path: Path to the input .hkl file.
     :type input_path: str
-    :param input_format: Format of the .hkl file. For reference see
-        :meth:`hikari.dataframes.HklFrame.interpret_hkl_format`.
+    :param input_format: Format of the .hkl file. For reference
+        see :meth:`hikari.dataframes.HklFrame.interpret_hkl_format`.
     :type input_format: str or dict
     :param input_wavelength: Wavelength of radiation utilised in experiment.
     :type input_wavelength: float or str
@@ -80,21 +80,21 @@ def dac_statistics(a, b, c, al, be, ga,
     :param space_group: Short Hermann-Mauguin name or index of space group.
         For details see table in hikari.symmetry.space_groups.
     :type space_group: str or int
-    :param opening_angle: Value of single opening angle as defined in
-        :meth:`hikari.dataframes.HklFrame.dac`.
+    :param opening_angle: Value of single opening angle as defined
+        in :py:meth:`hikari.dataframes.HklFrame.dac`.
     :type opening_angle: float
-    :param orientation: Crystal orientation as defined in
-        :class:`hikari.dataframes.BaseFrame`
+    :param orientation: Crystal orientation as defined
+        in :py:class:`hikari.dataframes.BaseFrame`
     :type orientation: tuple or numpy.array
     :param input_path: Path to the input .hkl file.
     :type input_path: str
-    :param input_format: Format of the .hkl file. For reference see
-        :meth:`hikari.dataframes.HklFrame.interpret_hkl_format`.
+    :param input_format: Format of the .hkl file. For reference
+        see :py:meth:`hikari.dataframes.HklFrame.interpret_hkl_format`.
     :type input_format: int or str or dict
     :param input_wavelength: Wavelength of radiation utilised in experiment.
     :type input_wavelength: float or str
     :param resolution: If given, calculate statistics only up to this value.
-    Please provide it as a distance in rec. space (twice the resolution in A-1).
+        Please provide it as a distance in rec. space (twice the resolution in A-1).
     :type resolution: float
     :return: None
     """

--- a/hikari/scripts/hkl_completeness.py
+++ b/hikari/scripts/hkl_completeness.py
@@ -15,7 +15,7 @@ import numpy as np
 def completeness_statistics(a, b, c, al, be, ga,
                             space_group='P-1',
                             input_path='shelx.hkl',
-                            input_format=4,
+                            input_format='shelx_4',
                             input_wavelength='CuKa'):
     """
     For a given experimental .hkl file calculate basic completeness statistics
@@ -40,7 +40,7 @@ def completeness_statistics(a, b, c, al, be, ga,
     :type input_path: str
     :param input_format: Format of the .hkl file. For reference see
         :meth:`hikari.dataframes.HklFrame.interpret_hkl_format`.
-    :type input_format: int or str or dict
+    :type input_format: str or dict
     :param input_wavelength: Wavelength of radiation utilised in experiment.
     :type input_wavelength: float or str
     :return: None
@@ -50,7 +50,7 @@ def completeness_statistics(a, b, c, al, be, ga,
     p.edit_cell(a=a, b=b, c=c, al=al, be=be, ga=ga)
     p.la = input_wavelength
     p.read(make_abspath(input_path), input_format)
-    p.stats(space_group=SG[space_group])
+    print(p.stats(space_group=SG[space_group]))
 
 
 def dac_statistics(a, b, c, al, be, ga,
@@ -212,24 +212,6 @@ def simulate_dac(a, b, c, al, be, ga,
 
 
 if __name__ == '__main__':
-    # from os import system
-    # sg = {'P-1': 'P-1',
-    #       'P2/m': 'P2om',
-    #       'Pmmm': 'Pmmm',
-    #       'P4/m': 'P4om',
-    #       'P4/mmm': 'P4ommm',
-    #       'Pm-3': 'Pm-3',
-    #       'Pm-3m': 'Pm-3m',
-    #       'P-3': 'P-3',
-    #       'P-3m1': 'P-3m1',
-    #       'P6/m': 'P6om',
-    #       'P6/mmm': 'P6ommm'}
-    # kwargs = {'a': 20, 'b': 20, 'c': 20, 'al': 90, 'be': 90,
-    #           'fix_scale': True, 'opening_angle': 45,
-    #           'output_quality': 5, 'wavelength': 0.42, 'resolution': 2.0}
-    # for k, v in sg.items():
-    #     name = 'CpltMap_la42oa45res50_{}'.format(v)
-    #     ga = 120 if v in {'P-3', 'P-3m1', 'P6om', 'P6ommm'} else 90
-    #     completeness_map(space_group=SG[k], ga=ga,
-    #                      output_name=name, **kwargs)
-    pass
+    completeness_statistics(5.641087, 5.641087, 5.641087, 90, 90, 90,
+                            space_group='Fm-3m', input_path='~/_/NaCl/NaCl.hkl',
+                            input_format='shelx_4', input_wavelength='CuKa')

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -90,7 +90,7 @@ def potency_map(a, b, c, al, be, ga,
     :param ga: Unit cell parameter *alpha* in degrees.
     :type ga: float
     :param space_group: Short Hermann-Mauguin name or index of space group.
-        For details see table in hikari.symmetry.space_groups.
+        For details see :py:mod:`hikari.symmetry.space_groups`.
     :type space_group: str or int
     :param axis: domain to calculate potency in. Accepts 'x'/ 'y'/ 'z' for h00/
         0k0/ 00l, 'xy'/'xz'/'yz' for hk0/ h0l/ 0kl, or '' for all reflections.
@@ -158,18 +158,17 @@ def potency_vs_dac_opening_angle(output_path='~/output.txt',
         side = 10 * precision**(1/3) / res  # adapt to res&la
         hkl_frame.edit_cell(a=side, b=side, c=side, al=90, be=90, ga=90)
         hkl_frame.fill(radius=res)
-        hkl_frame.find_equivalents()
         return hkl_frame
 
     p = _make_reference_ball()
-    v = fibonacci_sphere(10)
+    v = fibonacci_sphere(100)
     total = len(p)
     angles = np.linspace(start=90, stop=0, num=precision)
     out = open(make_abspath(output_path), 'w')
     out.write('#oa      cplt\n')
     for a in angles:  # for one random vector v
         c = p.dacs_count(opening_angle=a, vectors=v)
-        out.write(' {a:7.4f} {c:7.5f}\n'.format(a=a, c=np.mean(c)/total))
+        out.write(f' {a:7.4f} {np.mean(c)/total:7.5f}\n')
     out.close()
 
 
@@ -324,7 +323,7 @@ def dac_potency_around_axis(a, b, c, al, be, ga,
     :param ga: Unit cell parameter *gamma* in degrees.
     :type ga: float
     :param space_group: Short Hermann-Mauguin name or index of space group.
-        For details see table in hikari.symmetry.space_groups.
+        For details see :py:mod:`hikari.symmetry.space_groups`.
     :type space_group: str or int
     :param wavelength: Wavelength of radiation utilised in experiment.
     :type wavelength: float or str

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -10,6 +10,32 @@ from hikari.utility import make_abspath, weighted_quantile, \
     fibonacci_sphere, rotation_around, sph2cart, cart2sph, Interval
 from hikari.utility import GnuplotAngularHeatmapArtist, \
     MatplotlibAngularHeatmapArtist
+from .angular_explorer import AngularPotencyExplorer
+
+
+def potency_map2(a, b, c, al, be, ga,
+                 space_group='P1',
+                 axis='',
+                 fix_scale=False,
+                 histogram=True,
+                 opening_angle=35,
+                 orientation=None,
+                 path='~/sortav.lst',
+                 output_quality=3,
+                 resolution=1.2,
+                 wavelength='MoKa'):
+    ape = AngularPotencyExplorer()
+    ape.set_experimental(opening_angle=opening_angle,
+                         orientation=orientation,
+                         resolution=resolution)
+    ape.set_options(path=path, fix_scale=fix_scale,
+                    histogram=histogram, output_quality=output_quality)
+    ape.set_hkl_frame(a=a, b=b, c=c, al=al, be=be, ga=ga, axis=axis,
+                      space_group=space_group, wavelength=wavelength)
+    ape.explore()
+    ape.write_hist_file()
+    ape.draw_matplotlib_map()
+    ape.draw_gnuplot_map()
 
 
 def potency_map(a, b, c, al, be, ga,

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -28,8 +28,7 @@ def potency_map(a, b, c, al, be, ga,
 
     The script accepts unit cell & space group information, and predicts the
     completeness of fully merged data for investigated crystal in said group.
-    Results are logged into text files and drawn with gnuplot or matplotlib,
-    depending on settings.
+    Results are logged into text files and drawn with gnuplot or matplotlib.
 
     Potency is calculated and visualised on a unit-sphere orientation heatmap.
     Each point **p** is associated with a certain crystal orientation in DAC,
@@ -395,17 +394,5 @@ def dac_potency_around_axis(a, b, c, al, be, ga,
 
 
 if __name__ == '__main__':
-    # potency_map(10, 10, 10, 90, 90, 90, space_group='Pmmm',
-    #             resolution=1.2, output_directory='~/_/', output_name='_')
-    ori2 = np.array(((-0.0763491000, -0.0083505000, 0.0385930000),
-              (-0.0182458000, -0.0367852000, -0.0315399000),
-              (0.0609273000, -0.0215065000, 0.0389391000)))
-    # potency_map(a=10, b=10, c=10, al=90, be=100, ga=90, space_group='P21/c',
-    #              fix_scale=False,
-    #              output_directory='~/Documents/python_stubs/histogram_on_potency_map/hikari-0.1.4/', output_name='dev2_free',
-    #              output_quality=5, histogram=True, orientation=ori2)
-    potency_map(a=10, b=10, c=10, al=90, be=90, ga=120, space_group='P63/mcm',
-                fix_scale=True, resolution=2.0,
-                path='~/Documents/python_stubs/histogram_on_potency_map/hikari-0.1.4/dev2_fixed',
-                output_quality=5, histogram=True, orientation=ori2)
-    pass
+    potency_map(a=10, b=10, c=10, al=90, be=90, ga=120, space_group='P21/c',
+                path='~/_/potency.hkl', output_quality=5, wavelength='MoKa')

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -102,7 +102,8 @@ def potency_map(a, b, c, al, be, ga,
     :param opening_angle: Value of single opening angle as defined in
         :meth:`hikari.dataframes.HklFrame.dac`.
     :type opening_angle: float
-    :param orientation: 3x3 matrix of crystal orientation to be marked on a map
+    :param orientation: either a cif-style 3x3 matrix of crystal orientation or
+        a 3-length array with a diamond-perpendicular face to be marked on a map
     :type orientation: np.ndarray
     :param path: Path to a file where script is to be run. Extension is ignored,
         but file name will and must be the same for all input and output files.

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -10,7 +10,7 @@ from hikari.utility import make_abspath, weighted_quantile, \
     fibonacci_sphere, rotation_around, sph2cart, cart2sph, Interval
 from hikari.utility import GnuplotAngularHeatmapArtist, \
     MatplotlibAngularHeatmapArtist
-from .angular_explorer import AngularPotencyExplorer
+from hikari.scripts.angular_explorer import AngularPotencyExplorer
 
 
 def potency_map2(a, b, c, al, be, ga,

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -402,10 +402,10 @@ if __name__ == '__main__':
               (0.0609273000, -0.0215065000, 0.0389391000)))
     # potency_map(a=10, b=10, c=10, al=90, be=100, ga=90, space_group='P21/c',
     #              fix_scale=False,
-    #             output_directory='~/Documents/python_stubs/histogram_on_potency_map/hikari-0.1.4/', output_name='dev2_free',
+    #              output_directory='~/Documents/python_stubs/histogram_on_potency_map/hikari-0.1.4/', output_name='dev2_free',
     #              output_quality=5, histogram=True, orientation=ori2)
-    potency_map(a=10, b=10, c=10, al=90, be=100, ga=90, space_group='P21/c',
-                fix_scale=False,
-                path='~/Documents/python_stubs/histogram_on_potency_map/hikari-0.1.4/dev2_free',
+    potency_map(a=10, b=10, c=10, al=90, be=90, ga=120, space_group='P63/mcm',
+                fix_scale=True, resolution=2.0,
+                path='~/Documents/python_stubs/histogram_on_potency_map/hikari-0.1.4/dev2_fixed',
                 output_quality=5, histogram=True, orientation=ori2)
     pass

--- a/hikari/scripts/hkl_potency.py
+++ b/hikari/scripts/hkl_potency.py
@@ -158,18 +158,18 @@ def potency_vs_dac_opening_angle(output_path='~/output.txt',
         side = 10 * precision**(1/3) / res  # adapt to res&la
         hkl_frame.edit_cell(a=side, b=side, c=side, al=90, be=90, ga=90)
         hkl_frame.fill(radius=res)
+        hkl_frame.find_equivalents()
         return hkl_frame
 
     p = _make_reference_ball()
     v = fibonacci_sphere(100)
     total = len(p)
     angles = np.linspace(start=90, stop=0, num=precision)
-    out = open(make_abspath(output_path), 'w')
-    out.write('#oa      cplt\n')
-    for a in angles:  # for one random vector v
-        c = p.dacs_count(opening_angle=a, vectors=v)
-        out.write(f' {a:7.4f} {np.mean(c)/total:7.5f}\n')
-    out.close()
+    with open(make_abspath(output_path), 'w', buffering=1) as out:
+        out.write('#     oa potency\n')
+        for a in angles:  # for one random vector v
+            c = p.dacs_count(opening_angle=a, vectors=v)
+            out.write(f' {a:7.4f} {np.mean(c)/total:7.5f}\n')
 
 
 laue_space_groups = 'P-1', 'P2/m', 'Pmmm', 'P4/m', 'P4/mmm', 'P-3', 'P-3m1',\

--- a/hikari/scripts/r1_map.py
+++ b/hikari/scripts/r1_map.py
@@ -9,6 +9,32 @@ from hikari.dataframes import HklFrame, LstFrame
 from hikari.symmetry import SG, Group
 from hikari.utility import make_abspath, sph2cart, weighted_quantile, \
     GnuplotAngularHeatmapArtist, MatplotlibAngularHeatmapArtist, Interval
+from .angular_explorer import AngularR1Explorer
+
+
+def r1_map2(a, b, c, al, be, ga,
+                 space_group='P1',
+                 axis='',
+                 fix_scale=False,
+                 histogram=True,
+                 opening_angle=35,
+                 orientation=None,
+                 path='~/sortav.lst',
+                 output_quality=3,
+                 resolution=1.2,
+                 wavelength='MoKa'):
+    are = AngularR1Explorer()
+    are.set_experimental(opening_angle=opening_angle,
+                         orientation=orientation,
+                         resolution=resolution)
+    are.set_options(path=path, fix_scale=fix_scale,
+                    histogram=histogram, output_quality=output_quality)
+    are.set_hkl_frame(a=a, b=b, c=c, al=al, be=be, ga=ga, axis=axis,
+                      space_group=space_group, wavelength=wavelength)
+    are.explore()
+    are.write_hist_file()
+    are.draw_matplotlib_map()
+    are.draw_gnuplot_map()
 
 
 def r1_map(a, b, c, al, be, ga,

--- a/hikari/scripts/r1_map.py
+++ b/hikari/scripts/r1_map.py
@@ -9,192 +9,38 @@ from hikari.dataframes import HklFrame, LstFrame
 from hikari.symmetry import SG, Group
 from hikari.utility import make_abspath, sph2cart, weighted_quantile, \
     GnuplotAngularHeatmapArtist, MatplotlibAngularHeatmapArtist, Interval
-from hikari.scripts.angular_explorer import AngularR1Explorer
-
-
-def r1_map2(a, b, c, al, be, ga,
-                 space_group='P1',
-                 axis='',
-                 fix_scale=False,
-                 histogram=True,
-                 opening_angle=35,
-                 orientation=None,
-                 path='~/sortav.lst',
-                 output_quality=3,
-                 resolution=1.2,
-                 wavelength='MoKa'):
-    are = AngularR1Explorer()
-    are.set_experimental(opening_angle=opening_angle,
-                         orientation=orientation,
-                         resolution=resolution)
-    are.set_options(path=path, fix_scale=fix_scale,
-                    histogram=histogram, output_quality=output_quality)
-    are.set_hkl_frame(a=a, b=b, c=c, al=al, be=be, ga=ga, axis=axis,
-                      space_group=space_group, wavelength=wavelength)
-    are.explore()
-    are.write_hist_file()
-    are.draw_matplotlib_map()
-    are.draw_gnuplot_map()
+from hikari.scripts.angular_explorer import angular_property_explorer_factory
 
 
 def r1_map(a, b, c, al, be, ga,
            space_group='P1',
+           axis='',
            fix_scale=False,
+           histogram=True,
            opening_angle=35,
-           job_directory='~',
-           job_name='cplt_map',
+           orientation=None,
+           path='~/sortav.lst',
            output_quality=3,
            resolution=1.2,
            wavelength='MoKa'):
-    """ An elementary script to map R1 as a function of dac orientation """
-    hkl_path = make_abspath(job_directory, job_name + '.hkl')
-    res_path = make_abspath(job_directory, job_name + '.res')
-    dat_path = make_abspath(job_directory, job_name + '.dat')
-    lst_path = make_abspath(job_directory, job_name + '.lst')
-    png_path = make_abspath(job_directory, job_name + '.png')
-    sg = SG[space_group]
-    lg = sg.reciprocate()
-
-    def _read_hkl_frame():
-        """Make ball or axis of hkl which will be cut in further steps"""
-        _f = HklFrame()
-        _f.edit_cell(a=a, b=b, c=c, al=al, be=be, ga=ga)
-        _f.la = wavelength
-        _f.read(hkl_path=hkl_path, hkl_format='shelx_4')
-        _f.trim(limit=min(_f.r_lim, resolution))
-        _f.find_equivalents(point_group=lg)
-        return _f
-
-    p = _read_hkl_frame()
-    total_reflections = p.table['equiv'].nunique()
-
-    def _determine_theta_and_phi_limits():
-        """Define range of coordinates where potency map will be calculated.
-        Unit vectors v1, v2, v3 point in zenith z*, orthogonal x and product."""
-        _v1 = p.c_w / lin.norm(p.c_w)
-        _v2 = p.a_v / lin.norm(p.a_v)
-        _v3 = np.cross(_v1, _v2)
-
-        if sg.system in {Group.System.triclinic}:
-            _th_limits = Interval(0, 180)
-            _ph_limits = Interval(-45, 135)
-        elif sg.system in {Group.System.monoclinic}:
-            _th_limits = Interval(0, 180)
-            _ph_limits = Interval(0, 90)
-        elif sg.system in {Group.System.orthorhombic, Group.System.tetragonal,
-                         Group.System.cubic}:
-            _th_limits = Interval(0, 90)
-            _ph_limits = Interval(0, 90)
-        elif sg.system in {Group.System.trigonal, Group.System.hexagonal}:
-            _th_limits = Interval(0, 90)
-            _ph_limits = Interval(0, 120)
-        else:
-            raise ValueError('Unknown crystal system (trigonal not supported)')
-        return _v1, _v2, _v3, _th_limits, _ph_limits
-    v1, v2, v3, th_limits, ph_limits = _determine_theta_and_phi_limits()
-
-    def _determine_angle_res():
-        if output_quality not in {1, 2, 3, 4, 5}:
-            raise KeyError('output_quality should be 1, 2, 3, 4 or 5')
-        return {1: 15, 2: 10, 3: 5, 4: 2, 5: 1}[output_quality]
-    angle_res = _determine_angle_res()
-
-    th_range = th_limits.arange(step=angle_res)
-    ph_range = ph_limits.arange(step=angle_res)
-    th_mesh, ph_mesh = th_limits.mesh_with(ph_limits, step=angle_res)
-    data_dict = {'th': [], 'ph': [], 'cplt': [], 'r1': [], 'weight': []}
-
-    def orientation_weight(th, ph):
-        """Calculate how much each point should contribute to distribution"""
-        def sphere_cutout_area(th1, th2, ph_span):
-            """Calculate sphere area in specified ph and th degree range.
-            For exact math, see articles about spherical cap and sector."""
-            return np.deg2rad(abs(ph_span)) * \
-                   abs(np.cos(np.deg2rad(th1)) - np.cos(np.deg2rad(th2)))
-        th_max = min(th + angle_res / 2.0, th_limits[1])
-        th_min = max(th - angle_res / 2.0, th_limits[0])
-        ph_max = min(ph + angle_res / 2.0, ph_limits[1])
-        ph_min = max(ph - angle_res / 2.0, ph_limits[0])
-        return sphere_cutout_area(th_min, th_max, ph_max-ph_min)
-
-    def _calculate_completeness_mesh():
-        """Calculate completeness for each individual pair of theta and phi."""
-        _r1_mesh = np.zeros_like(th_mesh, dtype=float)
-        lst = open(lst_path, 'w+')
-        lst.write('#     th      ph      R1    cplt\n')
-        for i, th in enumerate(th_range):
-            for j, ph in enumerate(ph_range):
-                subdir = job_name + f'_th{int(th+.1)}_ph{int(ph+.1)}'
-                hkl_path2 = make_abspath(job_directory, subdir, job_name+'.hkl')
-                ins_path2 = make_abspath(job_directory, subdir, job_name+'.ins')
-                lst_path2 = make_abspath(job_directory, subdir, job_name+'.lst')
-                dir_path2 = make_abspath(job_directory, subdir)
-                Path(dir_path2).mkdir()
-                shutil.copy(res_path, ins_path2)
-                q = p.copy()
-                q.dac_trim(opening_angle, sph2cart(1.0, np.deg2rad(th),
-                                                   np.deg2rad(ph)))
-                q.write(hkl_path2, hkl_format='shelx_4')
-                count = q.table['equiv'].nunique()
-                os.system(f'cd {dir_path2}; shelxl {job_name}')
-                r1 = LstFrame().read_r1(lst_path2)
-                cplt = count / total_reflections
-                data_dict['th'].append(th)
-                data_dict['ph'].append(ph)
-                data_dict['cplt'].append(cplt)
-                data_dict['r1'].append(r1)
-                data_dict['weight'].append(orientation_weight(th, ph))
-                lst.write(f'{th:8.0f}{ph:8.0f}{r1:8.5}{cplt:8.5f}\n')
-                _r1_mesh[j][i] = r1
-            lst.write('\n')
-        index_max = np.unravel_index(np.argmax(_r1_mesh), _r1_mesh.shape)
-        best_th, best_ph = th_range[index_max[1]], ph_range[index_max[0]]
-        index_min = np.unravel_index(np.argmin(_r1_mesh), _r1_mesh.shape)
-        worst_th, worst_ph = th_range[index_min[1]], ph_range[index_min[0]]
-        q1, q2, q3 = weighted_quantile(values=data_dict['r1'],
-                                       quantiles=[0.25, 0.50, 0.75],
-                                       weights=data_dict['weight'])
-        avg_r = np.average(data_dict['r1'], weights=data_dict['weight'])
-        max_r = max(data_dict['r1'])
-        min_r = min(data_dict['r1'])
-        s = f'# descriptive statistics for r1:\n' \
-            f'# max ={max_r:8.5f} at th ={best_th :6.1f} ph ={best_ph :6.1f}\n'\
-            f'# min ={min_r:8.5f} at th ={worst_th:6.1f} ph ={worst_ph:6.1f}\n'\
-            f'# q_1 ={q1   :8.5f}\n' \
-            f'# q_2 ={q2   :8.5f}\n' \
-            f'# q_3 ={q3   :8.5f}\n' \
-            f'# avg ={avg_r:8.5f}\n'
-        lst.write(s)
-        lst.close()
-        np.savetxt(dat_path, _r1_mesh)
-        return data_dict
-
-    data_dict = _calculate_completeness_mesh()
-
-    ma = MatplotlibAngularHeatmapArtist()
-    ma.x_axis = p.a_w / lin.norm(p.a_w)
-    ma.y_axis = p.b_w / lin.norm(p.b_w)
-    ma.z_axis = p.c_w / lin.norm(p.c_w)
-    ma.heat_limits = (0 if fix_scale else min(data_dict['r1']),
-                      1 if fix_scale else max(data_dict['r1']))
-    ma.polar_limits = (min(th_limits), max(th_limits))
-    ma.azimuth_limits = (min(ph_limits), max(ph_limits))
-    ma.plot(png_path)
-
-    # plot potency map using external gnuplot
-    ga = GnuplotAngularHeatmapArtist()
-    ga.x_axis = p.a_w / lin.norm(p.a_w)
-    ga.y_axis = p.b_w / lin.norm(p.b_w)
-    ga.z_axis = p.c_w / lin.norm(p.c_w)
-    ga.heat_limits = (0 if fix_scale else min(data_dict['r1']) * 100,
-                      1 if fix_scale else max(data_dict['r1']) * 100)
-    ga.polar_limits = (min(th_limits), max(th_limits))
-    ga.azimuth_limits = (min(ph_limits), max(ph_limits))
-    ga.plot(png_path)
+    kwargs = locals()
+    ape = angular_property_explorer_factory.create(prop='r1')
+    ape.set_up(**kwargs)
+    ape.explore()
+    ape.write_hist_file()
+    ape.draw_matplotlib_map()
+    ape.draw_gnuplot_map()
 
 
 if __name__ == '__main__':
-    r1_map(5.64109, 5.64109, 5.64109, 90, 90, 90, space_group='Fm-3m',
-           job_directory='~/_/NaCl', job_name='NaCl',
-           output_quality=5, wavelength='MoKa')
+    # r1_map(5.64109, 5.64109, 5.64109, 90, 90, 90, space_group='Fm-3m',
+    #       job_directory='~/_/NaCl', job_name='NaCl',
+    #       output_quality=5, wavelength='MoKa')
+    # r1_map(5.64109, 5.64109, 5.64109, 90, 90, 90, space_group='Fm-3m',
+    #        job_directory='~/Documents/python_stubs/r1_map_tests2',
+    #        job_name='NaCl', output_quality=2, wavelength='MoKa')
+    r1_map(a=5.641087, b=5.641087, c=5.641087, al=90, be=90, ga=90,
+           space_group='Fm-3m', fix_scale=False,
+           path='~/Documents/python_stubs/r1_map_tests2/NaCl.hkl',
+           output_quality=2)
     pass

--- a/hikari/scripts/r1_map.py
+++ b/hikari/scripts/r1_map.py
@@ -9,7 +9,7 @@ from hikari.dataframes import HklFrame, LstFrame
 from hikari.symmetry import SG, Group
 from hikari.utility import make_abspath, sph2cart, weighted_quantile, \
     GnuplotAngularHeatmapArtist, MatplotlibAngularHeatmapArtist, Interval
-from .angular_explorer import AngularR1Explorer
+from hikari.scripts.angular_explorer import AngularR1Explorer
 
 
 def r1_map2(a, b, c, al, be, ga,

--- a/hikari/scripts/r1_map.py
+++ b/hikari/scripts/r1_map.py
@@ -12,6 +12,18 @@ def r1_map(a, b, c, al, be, ga,
            output_quality=3,
            resolution=1.2,
            wavelength='MoKa'):
+    """
+    Calculate and draw a r1 map for a given crystal in diamond anvil cell
+    (DAC) with a given opening angle, as a function of crystal orientation.
+
+    The script accepts unit cell & space group information, runs SHELXL,
+    and reads value of R1 after single refinement. Results are logged into text
+    files and drawn with gnuplot or matplotlib, depending on settings.
+
+    For further detail concerning r1_map, its basis and uses, refer to
+    :py:func:`hikari.scripts.potency_map`, as well as selected terminology
+    described in `this paper <https://doi.org/10.1107/S2052252521009532>`_.
+    """
     kwargs = locals()
     ape = angular_property_explorer_factory.create(prop='r1')
     ape.set_up(**kwargs)
@@ -22,14 +34,5 @@ def r1_map(a, b, c, al, be, ga,
 
 
 if __name__ == '__main__':
-    # r1_map(5.64109, 5.64109, 5.64109, 90, 90, 90, space_group='Fm-3m',
-    #       job_directory='~/_/NaCl', job_name='NaCl',
-    #       output_quality=5, wavelength='MoKa')
-    # r1_map(5.64109, 5.64109, 5.64109, 90, 90, 90, space_group='Fm-3m',
-    #        job_directory='~/Documents/python_stubs/r1_map_tests2',
-    #        job_name='NaCl', output_quality=2, wavelength='MoKa')
-    r1_map(a=5.641087, b=5.641087, c=5.641087, al=90, be=90, ga=90,
-           space_group='Fm-3m', fix_scale=False,
-           path='~/Documents/python_stubs/r1_map_tests2/NaCl.hkl',
-           output_quality=2)
-    pass
+    r1_map(5.64109, 5.64109, 5.64109, 90, 90, 90, space_group='Fm-3m',
+           path='~/_/NaCl/NaCl.hkl', output_quality=5, wavelength='MoKa')

--- a/hikari/scripts/r1_map.py
+++ b/hikari/scripts/r1_map.py
@@ -1,14 +1,3 @@
-import os
-from pathlib import Path
-import shutil
-
-import numpy as np
-from numpy import linalg as lin
-
-from hikari.dataframes import HklFrame, LstFrame
-from hikari.symmetry import SG, Group
-from hikari.utility import make_abspath, sph2cart, weighted_quantile, \
-    GnuplotAngularHeatmapArtist, MatplotlibAngularHeatmapArtist, Interval
 from hikari.scripts.angular_explorer import angular_property_explorer_factory
 
 

--- a/hikari/symmetry/operations.py
+++ b/hikari/symmetry/operations.py
@@ -235,11 +235,10 @@ class SymmOp:
             return '?'
 
     @property
-    def fold(self):
+    def fold(self) -> int:
         """
-        :return: number of times operation must be repeated to become inversion
-        or translation: n for n-fold axes, 2 for reflections, 1 for other (max6)
-        :rtype: int
+        Number of times operation must be repeated to become identity, inversion
+        or translation: n for n-fold axes, 2 for reflections, 1 for other (max 6)
         """
         op = SymmOp(self.tf) if self.det > 0 else SymmOp(-self.tf)
         for f in (1, 2, 3, 4, 5, 6):
@@ -248,11 +247,10 @@ class SymmOp:
         raise NotImplementedError('fold is not in range 1 to 6')
 
     @property
-    def order(self):
+    def order(self) -> int:
         """
-        :return: number of times operation has to be repeated to become
-        translation, eg.: n for all n-fold axes, 2 for other (max 6)
-        :rtype: int
+        Number of times operation has to be repeated to become
+        a translation, eg.: n for all n-fold axes, 2 for other (max 6)
         """
         for f in (1, 2, 3, 4, 5, 6):
             if pow(self, f, 1).typ is self.Type.identity:
@@ -260,28 +258,24 @@ class SymmOp:
         raise NotImplementedError('order is not in range 1 to 6')
 
     @property
-    def glide(self):
+    def glide(self) -> np.ndarray:
         """
-        :return: part of the translation vector stemming from operations' glide
-        :rtype: np.ndarray
+        Part of the translation vector stemming from operations' glide
         """
         return (self ** 24).__tl24 / 576 % 1
 
     @property
-    def glide_fold(self):
+    def glide_fold(self) -> int:
         """
-        :return: number of types glide component of the operation must be
-        repeated to contain only integer values, eg.: 3 for "6_2", 4 for "d"
-        :rtype:
+        Number of types glide component of the operation must be repeated
+        in order to contain only integer values, eg.: 3 for "6_2", 4 for "d"
         """
-
         return max([24 // t for t in [*self.__tl24, 24] if t != 0])
 
     @property
-    def origin(self):
+    def origin(self) -> np.ndarray:
         """
-        :return: selected point belonging to symmetry element of the operation
-        :rtype: np.ndarray
+        Selected point invariant to the symmetry operation
         """
         return (self.tl - self.glide) * 1 / 2
 
@@ -352,6 +346,7 @@ class SymmOp:
         """
         Transform operation as little as possible so that its symmetry element
         contains "point". To be used after "into" if used together.
+
         :param point: Target coordinates of point which should lie in element
         :type point: np.array
         :return: New symmetry operation which contains "point" in its element
@@ -366,7 +361,8 @@ class SymmOp:
         """
         Rotate operation so that its orientation changes to "direction", while
         preserving fractional glide. To be used before respective "at" method.
-        Might not work correctly for rhombohedral unit cell #TODO
+        Will most likely not work for unimplemented rhombohedral unit cells.
+
         :param direction: Target orientation for element of symmetry operation
         :type direction: np.ndarray
         :param hexagonal: True if operation is defined in hexagonal coordinates
@@ -411,6 +407,7 @@ class SymmOp:
     def transform(self, other):
         """
         Transform a column containing rows of coordinate points
+
         :param other: A vertical numpy array of coordinate triplets kept in rows
         :type other: np.ndarray
         :return: Same-shaped array of coordinate triplets transformed by self
@@ -424,6 +421,8 @@ class SymmOp:
 
     def extincts(self, hkl):
         """
+        Return boolean array with truth whenever reflection should be extinct
+
         :param hkl: An array containing one hkl or multiple hkls in columns
         :type hkl: np.ndarray
         :return: array of booleans, where extinct reflections are marked as True

--- a/hikari/utility/__init__.py
+++ b/hikari/utility/__init__.py
@@ -13,4 +13,4 @@ from .list_tools import cubespace, find_best, rescale_list_to_range,\
     rescale_list_to_other
 from .os_tools import make_abspath
 from .palettes import gnuplot_map_palette, mpl_map_palette
-from .artists import GnuplotAngularHeatmapArtist, MatplotlibAngularHeatmapArtist
+from .artists import artist_factory

--- a/hikari/utility/artists.py
+++ b/hikari/utility/artists.py
@@ -26,8 +26,8 @@ class Artist:
             if not len(iterable) == length and length is not 0:
                 raise TypeError()
         except TypeError:
-            raise ArtistError(f'object {iterable} should be an iterable' + \
-                              f'of length {length}' if length else '')
+            raise ArtistError(f'object {iterable} should be an iterable'
+                              f' of length {length}' if length else '')
 
     @abc.abstractmethod
     def plot(self, path):

--- a/hikari/utility/artists.py
+++ b/hikari/utility/artists.py
@@ -16,6 +16,21 @@ class ArtistError(Exception):
         super().__init__(message)
 
 
+class ArtistFactory:
+    """A factory method for creating artists."""
+    def __init__(self):
+        self._artists = {}
+
+    def register(self, name, artist):
+        self._artists[name] = artist
+
+    def create(self, name, **kwargs):
+        artist = self._artists.get(name)
+        if not artist:
+            raise ValueError(f'Artist called "{name}" has not been registered!')
+        return artist(**kwargs)
+
+
 class Artist:
     """Base class used for plotting matplotlib and gnuplot plots"""
 
@@ -270,3 +285,10 @@ class MatplotlibAngularHeatmapArtist(MatplotlibArtist, AngularHeatmapArtist):
                         antialiased=False, facecolors=color_mesh)
         pyplot.subplots_adjust(left=0.0, bottom=0.0, right=0.95, top=1.0)
         pyplot.savefig(png_path, dpi=100, format='png', bbox_inches=None)
+
+
+artist_factory = ArtistFactory()
+artist_factory.register(name='gnuplot_angular_heatmap_artist',
+                        artist=GnuplotAngularHeatmapArtist)
+artist_factory.register(name='matplotlib_angular_heatmap_artist',
+                        artist=MatplotlibAngularHeatmapArtist)

--- a/hikari/utility/artists.py
+++ b/hikari/utility/artists.py
@@ -4,7 +4,8 @@ from matplotlib import pyplot, colors, cm
 from mpl_toolkits.mplot3d import art3d
 import numpy as np
 
-from hikari.utility import gnuplot_map_palette, mpl_map_palette, sph2cart
+from hikari.utility import gnuplot_map_palette, make_abspath, \
+    mpl_map_palette, sph2cart
 from hikari.resources import gnuplot_angular_heatmap_template
 
 
@@ -161,7 +162,7 @@ class GnuplotAngularHeatmapArtist(GnuplotArtist, AngularHeatmapArtist):
         return '\n'.join([label.format(*f) for f in self.focus])
 
     def plot(self, path):
-        png_path = Path(path)
+        png_path = Path(make_abspath(path))
         directory, stem, ext = png_path.parent, png_path.stem, png_path.suffix
         gnu_name = png_path.stem + self.GNUPLOT_EXTENSION
         gnu_path = Path().joinpath(directory, gnu_name)
@@ -197,7 +198,7 @@ class MatplotlibAngularHeatmapArtist(MatplotlibArtist, AngularHeatmapArtist):
 
     def plot(self, path):
         # OS and I/O operations
-        png_path = Path(path)
+        png_path = Path(make_abspath(path))
         directory, stem, ext = png_path.parent, png_path.stem, png_path.suffix
         mesh_name = png_path.stem + self.MESH_EXTENSION
         mesh_path = Path().joinpath(directory, mesh_name)

--- a/hikari/utility/interval.py
+++ b/hikari/utility/interval.py
@@ -101,6 +101,9 @@ class Interval:
     def __contains__(self, item):
         return self.left <= _min(item) and _max(item) <= self.right
 
+    def __len__(self):
+        return 2
+
     def arange(self, step=1):
         """
         Return a 1D-list of values from left to right every step

--- a/hikari/utility/math_tools.py
+++ b/hikari/utility/math_tools.py
@@ -48,12 +48,12 @@ def cart2sph(x, y, z):
     :param z: Cartesian coordinates or vector z
     :type z: float or np.ndarray
     :return: Spherical coordinates: radius, polar angle, and azimuth angle
-    :rtype: tuple[float, float, float] or tuple[np.ndarray, np.ndarray, np.ndarray]
+    :rtype: np.ndarray
     """
     r = (x ** 2 + y ** 2 + z ** 2) ** 0.5
     p = np.arccos(z / r)
     a = np.arctan2(y, x)
-    return r, p, a
+    return np.array([r, p, a])
 
 
 def sph2cart(r, p, a):
@@ -67,12 +67,12 @@ def sph2cart(r, p, a):
     :param a: Spherical coordinate or vector azimuth angle
     :type a: float or np.ndarray
     :return: Cartesian coordinates: x, y, and z
-    :rtype: tuple[float, float, float] or tuple[np.ndarray, np.ndarray, np.ndarray]
+    :rtype: np.ndarray
     """
     x = r * np.cos(a) * np.sin(p)
     y = r * np.sin(a) * np.sin(p)
     z = r * np.cos(p)
-    return x, y, z
+    return np.array([x, y, z])
 
 
 def fibonacci_sphere(samples=1, seed=1337):

--- a/hikari/utility/math_tools.py
+++ b/hikari/utility/math_tools.py
@@ -227,5 +227,3 @@ def weighted_quantile(values, quantiles, weights=None):
     results_0to1 = np.interp(quantiles, weighted_cumsum_0to1, values)
     results_1to0 = np.interp(1-quantiles, weighted_cumsum_1to0, np.flip(values))
     return (results_0to1 + results_1to0) / 2.0
-
-# TODO later check scipy.spatial.transform.Rotation.from_rotvec as substitute

--- a/hikari/utility/math_tools.py
+++ b/hikari/utility/math_tools.py
@@ -143,7 +143,7 @@ def rotation_from(from_, to):
     :type from_: np.ndarray
     :param to: A 3D vector onto which `from` will have been rotated.
     :type to: np.ndarray
-    :return: Matrix associated with rotation of `from` onto `to.
+    :return: Matrix associated with rotation of `from` onto `to`.
     :rtype: np.ndarray
     """
     if from_.size != 3:


### PR DESCRIPTION
Previously the `potency_map` and hidden `r1_map` utilised two different scripts are were responsible themselves for drawing the data. This required updating two independent parts of code whenever any change was planned, so the scripts were generalised into two `AngularPotencyExplorer` and `AngularR1Explorer` classes, mostly based on common `AngularPropertyExplorer` class and registered in dedicated factory methods. Tests show that resulting approach is marginally slower, but can be easily modified at the same time due to a new file structure. As a result, many minor enhancements such as drawing experimental `focus` point based on both experimental `orientation` matrix and diamond-perpendicular crystal face could be implemented.

Other than previous changes, many small corrections to doc-strings and utility methods were introduced. The documentation has been also rebuild to describe `hikari` correctly instead of the old project.