### PR TITLE
Similarity

### DIFF
--- a/hikari/scripts/compare_adps.py
+++ b/hikari/scripts/compare_adps.py
@@ -7,13 +7,13 @@ from hikari.dataframes import BaseFrame, CifFrame, UBaseFrame
 from hikari.utility import make_abspath, cfloat, det3x3, chemical_elements
 
 
-def calculate_similarity_indices(cif1_path,
-                                 cif2_path=None,
-                                 cif1_block=None,
-                                 cif2_block=None,
-                                 normalize=False,
-                                 output_path=None,
-                                 uncertainties=True):
+def calculate_similarity_indices(cif1_path: str,
+                                 cif2_path: str = None,
+                                 cif1_block: str = None,
+                                 cif2_block: str = None,
+                                 output_path: str = None,
+                                 normalize: bool = False,
+                                 uncertainties: bool = True) -> None:
     """
     Compare Anisotropic Displacement Parameters of all atoms in two cif blocks
     and return a Similarity Index (SI) for these pairs of atoms that exist
@@ -59,27 +59,20 @@ def calculate_similarity_indices(cif1_path,
     https://doi.org/10.1107/S0108768106020787.
 
     :param cif1_path: Absolute or relative path to the first cif file.
-    :type cif1_path: str
     :param cif2_path: Absolute or relative path to the second cif file.
         If not specified, it is assumed equal to `cif1_path`.
-    :type cif2_path: str
     :param cif1_block: Name of the first data block used in SI determination.
         It points to the data block inside the file specified by `cif1_path`.
         If not specified, the first block found in said file will be used.
-    :type cif1_block: str
     :param cif2_block: Name of the second data block used in SI determination.
         It points to the data block inside the file specified by `cif2_path`.
         If not specified, the first unused block in said file will be used.
-    :type cif2_block: str
     :param output_path: Path where the output of the program should be written.
-    :type output_path: str
     :param uncertainties: If True, propagate the standard deviations of
         individual ADPs' and cif1's unit cell to estimate SI's uncertainties.
-    :type uncertainties: bool
     :param normalize: If True, equalize the volume of displacement ellipsoids
         by normalizing the determinants of ADP matrices expressed in cartesian
         coordinates. As a result, SI is a function of displacement "shape" only.
-    :type normalize: bool
     """
 
     u_type = ufloat_fromstr if uncertainties else cfloat

--- a/hikari/scripts/compare_adps.py
+++ b/hikari/scripts/compare_adps.py
@@ -203,4 +203,4 @@ def calculate_similarity_indices(cif1_path,
 if __name__ == '__main__':
     calculate_similarity_indices('~/_/si/1.cif',
                                  '~/_/si/2.cif',
-                                 output_path='~/x/HiPHAR/anders_script/si_compare.txt')
+                                 output_path='~/_/output.txt')

--- a/test/NaCl.cif
+++ b/test/NaCl.cif
@@ -9911,5 +9911,25 @@ loop_
  Na2 Cl1 Na1 90.0 1_554 5_445 ?
  Na2 Cl1 Na2 180.0 1_554 . ?
 
+################################################################################
 
+data_NaCl_negative_ADPs
 
+_symmetry_Int_Tables_number        12
+_cell_length_a                     5.6411(1)
+_cell_length_b                     5.6411(1)
+_cell_length_c                     5.6411(1)
+_cell_angle_alpha                  90
+_cell_angle_beta                   90
+_cell_angle_gamma                  90
+
+loop_
+  _atom_site_aniso_label
+  _atom_site_aniso_U_11
+  _atom_site_aniso_U_22
+  _atom_site_aniso_U_33
+  _atom_site_aniso_U_23
+  _atom_site_aniso_U_13
+  _atom_site_aniso_U_12
+ Cl1 0.01793(4)  0.01793(4) 0.01793(4) 0.000 0.000 0.000
+ Na1 -0.02129(6) 0.02129(6) 0.02129(6) 0.000 0.000 0.000

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -1,0 +1,69 @@
+import pathlib
+import tempfile
+import unittest
+
+from hikari.scripts import calculate_similarity_indices
+
+
+nacl_cif_path = str(pathlib.Path(__file__).parent.joinpath('NaCl.cif'))
+
+
+class TestCompareADPsScripts(unittest.TestCase):
+    temp_dir = tempfile.TemporaryDirectory()
+    output1_path = str(pathlib.Path(temp_dir.name) / 'similarity.out')
+    output2_path = str(pathlib.Path(temp_dir.name) / 'similarity.out')
+
+    def test_calculate_similarity_index_for_implicit_cif2_path(self):
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     output_path=self.output1_path)
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     cif2_path=nacl_cif_path,
+                                     cif1_block='NaCl',
+                                     cif2_block='NaCl_olex2_C2/m',
+                                     output_path=self.output2_path)
+        with open(self.output1_path, 'r') as out1:
+            with open(self.output2_path, 'r') as out2:
+                self.assertEqual(out1.read(), out2.read())
+
+    def test_calculate_similarity_index_for_implicit_cif_blocks(self):
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     cif2_path=nacl_cif_path,
+                                     output_path=self.output1_path)
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     cif2_path=nacl_cif_path,
+                                     cif1_block='NaCl',
+                                     cif2_block='NaCl',
+                                     output_path=self.output2_path)
+        with open(self.output1_path, 'r') as out1:
+            with open(self.output2_path, 'r') as out2:
+                self.assertEqual(out1.read(), out2.read())
+
+    def test_calculate_similarity_index_for_identical(self):
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     cif2_path=nacl_cif_path,
+                                     output_path=self.output1_path)
+        with open(self.output1_path, 'r') as out:
+            last_line_contents = out.readlines()[-1].strip().split()
+            self.assertAlmostEqual(float(last_line_contents[-1]), 0.0)
+            self.assertAlmostEqual(float(last_line_contents[-3]), 0.0)
+
+    def test_calculate_similarity_index_for_different(self):
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     output_path=self.output1_path)
+        with open(self.output1_path, 'r') as out:
+            last_line_contents = out.readlines()[-1].strip().split()
+            self.assertNotAlmostEqual(float(last_line_contents[-1]), 0.0)
+            self.assertNotAlmostEqual(float(last_line_contents[-3]), 0.0)
+
+    def test_calculate_similarity_index_for_negative_adps(self):
+        calculate_similarity_indices(cif1_path=nacl_cif_path,
+                                     cif1_block='NaCl',
+                                     cif2_block='NaCl_negative_ADPs',
+                                     output_path=self.output1_path)
+        with open(self.output1_path, 'r') as out:
+            last_line_contents = out.readlines()[-1].strip().split()
+            self.assertAlmostEqual(float(last_line_contents[-3]), 50.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Script `calculate_similarity_indices` has been further expanded and bug-tested. In particular, the similarity index of an individual atom as made equal to exactly one whenever uncertainties package can handle it - which happens whenever the determinant or eigenvalues of ADP matrix are negative.