### PR TITLE
M80

### DIFF
--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -1116,9 +1116,10 @@ class HklReader(HklIo):
         """
         slice_end = list(np.cumsum(self._format_dict['widths']))
         slice_beg = [0] + slice_end[:-1]
-        parsed = [line[beg:end] for beg, end in zip(slice_beg, slice_end)]
-        parsed = np.array(parsed)
         try:
+            parsed = [line[beg:end] for beg, end in zip(slice_beg, slice_end)]
+            parsed = np.array(parsed)
+            assert min([len(p) for p in parsed]) > 0
             assert len(parsed) == len(self._format_dict['widths'])
         except (ValueError, AssertionError):
             return None

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -263,9 +263,17 @@ class HklKeys:
         'reduce_behaviour': 'keep',
         'type': int
     }
+    ___ = {
+        'default': '',
+        'description': 'Dummy column for irrelevant data',
+        'imperative': False,
+        'dtype': 'str',
+        'reduce_behaviour': 'keep',
+        'type': str
+    }
     defined_keys = {'h', 'k', 'l', 'F', 'I', 'si', 'sf', 'b', 'm', 'la', 'ph',
                     'u', 'r', 't', 'u1', 'u2', 'u3', 'v1', 'v2', 'v3',
-                    'x', 'y', 'z', 'ze', 'ze2', 'Iosi', 'Icsi', 'equiv'}
+                    'x', 'y', 'z', 'ze', 'ze2', 'Iosi', 'Icsi', 'equiv', '_'}
     # TODO check if needed and cplt?
 
     def __init__(self, keys=()):

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -964,6 +964,9 @@ class HklIo:
         | free_6   |          | h -4 k -4 l -4         | NO   | YES  | YES    |
         |          |          | I -8 si -8 m -4        |      | (a)  |        |
         +----------+----------+------------------------+------+------+--------+
+        | m80      |          | h 4 k 4 l 4 b 4 F 12   | YES  | YES  | NO     |
+        |          |          | None 132               | (b)  | (b)  |        |
+        +----------+----------+------------------------+------+------+--------+
         | shelx_2  | 2        | h 4 k 4 l 4 I 8 si 8   | NO   | YES  | NO     |
         |          |          | b 4 la 8               |      | (a)  |        |
         +----------+----------+------------------------+------+------+--------+
@@ -986,36 +989,36 @@ class HklIo:
         |          |          | Ic 14 I 14 si 13       | (*)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | tonto_F  |          | h -4 k -4 l -4         | YES  | YES  | YES    |
-        |          |          | F -8 sf -8             | (b)  | (b)  |        |
+        |          |          | F -8 sf -8             | (c)  | (c)  |        |
         +----------+----------+------------------------+------+------+--------+
         | tonto_I  | tonto    | h -4 k -4 l -4         | YES  | YES  | YES    |
-        |          |          | I -8 si -8             | (b)  | (b)  |        |
+        |          |          | I -8 si -8             | (c)  | (c)  |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_F6    |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | F -13 sf -13           | (c)  |      |        |
+        |          |          | F -13 sf -13           | (d)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_F7    |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | F -13 sf -13 t -10     | (c)  |      |        |
+        |          |          | F -13 sf -13 t -10     | (d)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_F-7   |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | F -13 sf -13 ph -10    | (c)  |      |        |
+        |          |          | F -13 sf -13 ph -10    | (d)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_F13   |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | F -13 sf -13 t -10     | (c)  |      |        |
+        |          |          | F -13 sf -13 t -10     | (d)  |      |        |
         |          |          | u1 -10 u2 -10 u3 -10   |      |      |        |
         |          |          | v1 -10 v2 -10 v3 -10   |      |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_I6    | xd       | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | I -13 si -13           | (c)  |      |        |
+        |          |          | I -13 si -13           | (d)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_I7    |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | I -13 si -13 t -10     | (c)  |      |        |
+        |          |          | I -13 si -13 t -10     | (d)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_I-7   |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | I -13 si -13 ph -10    | (c)  |      |        |
+        |          |          | I -13 si -13 ph -10    | (d)  |      |        |
         +----------+----------+------------------------+------+------+--------+
         | xd_I13   |          | h -4 k -4 l -4 b -3    | YES  | NO   | YES    |
-        |          |          | I -13 si -13 t -10     | (c)  |      |        |
+        |          |          | I -13 si -13 t -10     | (d)  |      |        |
         |          |          | u1 -10 u2 -10 u3 -10   |      |      |        |
         |          |          | v1 -10 v2 -10 v3 -10   |      |      |        |
         +----------+----------+------------------------+------+------+--------+
@@ -1030,11 +1033,13 @@ class HklIo:
 
         - Suffix (a) is a zero-line: a shelx ending line with h = k = l = 0,
 
-        - Prefix and suffix (b) are tonto-characteristic beginning/end of file,
+        - Prefix and suffix (b) express a superflip-style block/start end,
 
-        - Prefix (c) is an xd-characteristic line with info about file content.
+        - Prefix and suffix (c) are tonto-characteristic beginning/end of file,
 
-        Pre/suffixes denoted with (*) are not suported in terms of writing.
+        - Prefix (d) is an xd-characteristic line with info about file content.
+
+        Pre/suffixes denoted with (*) are not supported in terms of writing.
         A custom hkl file format can be defined by providing
         a *format string* instead of 'Name'.
         The string should look like the ones in column "contents".

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -263,7 +263,7 @@ class HklKeys:
         'reduce_behaviour': 'keep',
         'type': int
     }
-    ___ = {
+    __None = {
         'default': '',
         'description': 'Dummy column for irrelevant data',
         'imperative': False,
@@ -273,7 +273,7 @@ class HklKeys:
     }
     defined_keys = {'h', 'k', 'l', 'F', 'I', 'si', 'sf', 'b', 'm', 'la', 'ph',
                     'u', 'r', 't', 'u1', 'u2', 'u3', 'v1', 'v2', 'v3',
-                    'x', 'y', 'z', 'ze', 'ze2', 'Iosi', 'Icsi', 'equiv', '_'}
+                    'x', 'y', 'z', 'ze', 'ze2', 'Iosi', 'Icsi', 'equiv', 'None'}
     # TODO check if needed and cplt?
 
     def __init__(self, keys=()):

--- a/hikari/resources/hkl_formats_defined.json
+++ b/hikari/resources/hkl_formats_defined.json
@@ -120,6 +120,26 @@
             -4
         ]
     },
+    "m80": {
+        "labels": [
+            "h",
+            "k",
+            "l",
+            "b",
+            "F",
+            "_"
+        ],
+        "prefix": "Block1 begin",
+        "suffix": "Block1 end",
+        "widths": [
+            4,
+            4,
+            4,
+            4,
+            12,
+            144
+        ]
+    },
     "shelx_2": {
         "labels": [
             "h",

--- a/hikari/resources/hkl_formats_defined.json
+++ b/hikari/resources/hkl_formats_defined.json
@@ -127,7 +127,8 @@
             "l",
             "b",
             "F",
-            "_"
+            "sf",
+            "None"
         ],
         "prefix": "Block1 begin",
         "suffix": "Block1 end",
@@ -137,7 +138,8 @@
             4,
             4,
             12,
-            144
+            12,
+            132
         ]
     },
     "shelx_2": {


### PR DESCRIPTION
Added a limited support for reading `m80`-type files from superflip. Only some parameter  are read correctly, eg. h, k, l, batch number, and structure factor. Rest of the parameters is either read incorrectly to allow reading file (eg. sigma(F) is made equal to F) or ignored.