### PR TITLE
Reduction

### DIFF
--- a/hikari/dataframes/base.py
+++ b/hikari/dataframes/base.py
@@ -1,5 +1,31 @@
 import numpy as np
 from hikari.utility import angle2rad, cfloat, det3x3
+from hikari.utility import str2array as s2a
+
+
+class Selling:
+    """
+    Dataclass for Selling parameters, matrices, and other definitions
+    used in obtaining reduced unit cell.
+    """
+
+    class S6:
+        """Dataclass for matrices used in S6 Selling scalar space"""
+        S1_FLIP_MATRIX = s2a('-100000/110000/100010/-100100/101000/100001')
+        S2_FLIP_MATRIX = s2a('110000/0-10000/010100/011000/0-10010/010001')
+        S3_FLIP_MATRIX = s2a('101000/001100/00-1000/011000/001010/00-1001')
+        S4_FLIP_MATRIX = s2a('100-100/001100/010100/000-100/000110/000101')
+        S5_FLIP_MATRIX = s2a('001010/0100-10/100010/000110/0000-10/000011')
+        S6_FLIP_MATRIX = s2a('010001/100001/00100-1/000101/000011/00000-1')
+
+    class E3:
+        """Dataclass for matrices used in euclidean E3 vector space"""
+        S1_FLIP_MATRIX = s2a('110/0-10/001')
+        S2_FLIP_MATRIX = s2a('-100/110/001')
+        S3_FLIP_MATRIX = s2a('-100/010/101')
+        S4_FLIP_MATRIX = s2a('-100/110/101')
+        S5_FLIP_MATRIX = s2a('110/0-10/011')
+        S6_FLIP_MATRIX = s2a('101/011/00-1')
 
 
 class BaseFrame:

--- a/hikari/dataframes/base.py
+++ b/hikari/dataframes/base.py
@@ -27,6 +27,49 @@ class Selling:
         S5_FLIP_MATRIX = s2a('110/0-10/011')
         S6_FLIP_MATRIX = s2a('101/011/00-1')
 
+    def __init__(self, basis_matrix: np.ndarray) -> None:
+        self.a, self.b, self.c = np.vsplit(basis_matrix)
+
+    @property
+    def d(self) -> np.ndarray:
+        return -self.a - self.b - self.c
+
+    @property
+    def s(self) -> np.ndarray:
+        return np.array(np.dot(self.b, self.c), np.dot(self.a, self.c),
+                        np.dot(self.a, self.b), np.dot(self.a, self.d),
+                        np.dot(self.b, self.d), np.dot(self.c, self.d))
+
+    def _reduce(self):
+        reduction_cycle = 0
+        s = self.s
+        e3_sum_transformation = np.eye(3)
+        while reduction_cycle < 1000:
+            if s[0] > 0:
+                s6_transformation = self.S6.S1_FLIP_MATRIX
+                e3_transformation = self.E3.S1_FLIP_MATRIX
+            elif s[1] > 0:
+                s6_transformation = self.S6.S1_FLIP_MATRIX
+                e3_transformation = self.E3.S1_FLIP_MATRIX
+            elif s[2] > 0:
+                s6_transformation = self.S6.S1_FLIP_MATRIX
+                e3_transformation = self.E3.S1_FLIP_MATRIX
+            elif s[3] > 0:
+                s6_transformation = self.S6.S1_FLIP_MATRIX
+                e3_transformation = self.E3.S1_FLIP_MATRIX
+            elif s[4] > 0:
+                s6_transformation = self.S6.S1_FLIP_MATRIX
+                e3_transformation = self.E3.S1_FLIP_MATRIX
+            elif s[5] > 0:
+                s6_transformation = self.S6.S1_FLIP_MATRIX
+                e3_transformation = self.E3.S1_FLIP_MATRIX
+            else:
+                # reorder vectors so that a <= b <= c <= d
+                return 0
+            s = s6_transformation @ s
+            e3_sum_transformation = e3_transformation @ e3_sum_transformation
+        raise TimeoutError('Number of reduction cycles exceeded maximum (1000)')
+
 
 class BaseFrame:
     """
@@ -284,7 +327,7 @@ class BaseFrame:
     @property
     def A_d(self):
         """
-        :return: Matrix A with vertically stacked direct space vectors.
+        :return: Basis matrix A with vertically stacked direct space vectors.
         :rtype: np.array
         """
         return np.vstack([self._a_v, self._b_v, self._c_v])
@@ -380,7 +423,7 @@ class BaseFrame:
     @property
     def A_r(self):
         """
-        :return: Matrix A\* with vertically stacked reciprocal space vectors.
+        :return: Basis matrix A\* with vertically stacked reciprocal space vectors.
         :rtype: np.array
         """
         return np.vstack([self._a_w, self._b_w, self._c_w])

--- a/hikari/dataframes/base.py
+++ b/hikari/dataframes/base.py
@@ -381,14 +381,14 @@ class BaseFrame:
         s2a('-100/110/101'), s2a('110/0-10/011'), s2a('101/011/00-1')]
 
     @property
-    def reduced_cell(self):
-        """Instance of `BaseFrame` with Selling-reduced unit cell"""
+    def semi_reduced_cell(self):
+        """Instance of `BaseFrame` with not-unique reduced unit cell"""
         raise NotImplementedError
         return 0
 
     @property
-    def reduction_matrix(self):
-        """Matrix transforming this cell to the Selling-reduced cell"""
+    def semi_reduction_matrix(self):
+        """Matrix transforming this cell to not-unique reduced cell"""
         a, b, c = self.a_v, self.b_v, self.c_v
         d = -a - b - c
         s = np.array([np.dot(b, c), np.dot(a, c), np.dot(a, b),
@@ -402,6 +402,10 @@ class BaseFrame:
                 e3_trans_total = e3_trans @ e3_trans_total
                 s = s6_trans @ s
             else:
-                # reorder vectors so that a <= b <= c <= d
-                return e3_trans_total
+                a, b, c = e3_trans_total @ self.A_d
+                d = -a - b - c
+                a2, b2 = np.dot(a, a), np.dot(b, b)
+                c2, d2 = np.dot(c, c), np.dot(d, d)
+                length_order = np.array([a2, b2, c2, d2]).argsort()
+                return (e3_trans_total @ self.A_d)[length_order]
         raise RuntimeError("Number of reduction cycles exceeded maximum (1000)")

--- a/hikari/dataframes/base.py
+++ b/hikari/dataframes/base.py
@@ -379,33 +379,3 @@ class BaseFrame:
     SELLING_E3_TRANSFORMATIONS = [
         s2a('110/0-10/001'), s2a('-100/110/001'), s2a('-100/010/101'),
         s2a('-100/110/101'), s2a('110/0-10/011'), s2a('101/011/00-1')]
-
-    @property
-    def semi_reduced_cell(self):
-        """Instance of `BaseFrame` with not-unique reduced unit cell"""
-        raise NotImplementedError
-        return 0
-
-    @property
-    def semi_reduction_matrix(self):
-        """Matrix transforming this cell to not-unique reduced cell"""
-        a, b, c = self.a_v, self.b_v, self.c_v
-        d = -a - b - c
-        s = np.array([np.dot(b, c), np.dot(a, c), np.dot(a, b),
-                      np.dot(a, d), np.dot(b, d), np.dot(c, d)])
-        e3_trans_total = np.eye(3)
-        for _ in range(1000):
-            largest_scalar_index = np.argmax(s)
-            if s[largest_scalar_index] > 0:
-                e3_trans = self.SELLING_E3_TRANSFORMATIONS[largest_scalar_index]
-                s6_trans = self.SELLING_S6_TRANSFORMATIONS[largest_scalar_index]
-                e3_trans_total = e3_trans @ e3_trans_total
-                s = s6_trans @ s
-            else:
-                a, b, c = e3_trans_total @ self.A_d
-                d = -a - b - c
-                a2, b2 = np.dot(a, a), np.dot(b, b)
-                c2, d2 = np.dot(c, c), np.dot(d, d)
-                length_order = np.array([a2, b2, c2, d2]).argsort()
-                return (e3_trans_total @ self.A_d)[length_order]
-        raise RuntimeError("Number of reduction cycles exceeded maximum (1000)")

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -610,14 +610,20 @@ class HklFrame(BaseFrame):
             return hkls[lin.norm(hkls @ xyz, axis=1) <= radius]
         hkl = _make_hkl_ball()
 
+        def increment_index_limit(index: int) -> int:
+            if index >= self.HKL_LIMIT:
+                msg = 'Attempting to use index > HKL_LIMIT of {} when filling'
+                raise ValueError(msg.format(self.HKL_LIMIT))
+            else:
+                return min(math.ceil(index * 1.1), self.HKL_LIMIT)
+
         # increase the ball size until all needed points are in
         previous_length = -1
-        while len(hkl) > previous_length \
-                and max(max_h, max_k, max_l) <= self.HKL_LIMIT:
+        while len(hkl) > previous_length:
             previous_length = len(hkl)
-            max_h = math.ceil(max_h * 1.2)
-            max_k = math.ceil(max_k * 1.2)
-            max_l = math.ceil(max_l * 1.2)
+            max_h = increment_index_limit(max_h)
+            max_k = increment_index_limit(max_k)
+            max_l = increment_index_limit(max_l)
             hkl = _make_hkl_ball(max_h, max_k, max_l)
 
         # create new dataframe using obtained ball of data
@@ -1327,3 +1333,14 @@ class HklToResConverter:
 
     # TODO wrap table/data in getter/setter and make it automatically place,
     # TODO refresh, set keys etc.
+
+
+if __name__ == "__main__":
+    h1 = HklFrame()
+    h1.edit_cell(a=30, b=30, c=30, al=10, be=10, ga=10)
+    h1.fill()
+    h2 = HklFrame()
+    h2.edit_cell(a=30, b=30, c=30, al=10, be=10, ga=10)
+    h2.fill2()
+    h2.to_res('~/_/skew.res')
+

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -1,5 +1,4 @@
 import copy
-import math
 import random
 
 import numpy as np

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -565,39 +565,13 @@ class HklFrame(BaseFrame):
             self.place()
         self._recalculate_structure_factors_and_intensities()
 
-    def fill(self, radius=2.0):
+    def fill(self, radius: float = 2.0) -> None:
         """
         Fill dataframe with all reflections within *radius* from space origin.
 
         :param radius: Maximum distance from the reciprocal space origin
             to placed reflection (in reciprocal Angstrom).
-        :type radius: float
         """
-
-        max_index = 25
-
-        # make an initial guess of the hkl ball
-        def _make_hkl_ball(i=max_index):
-            hkl_grid = np.mgrid[-i:i:2j*i+1j, -i:i:2j*i+1j, -i:i:2j*i+1j]
-            hkls = np.stack(hkl_grid, -1).reshape(-1, 3)
-            xyz = np.array((self.a_w, self.b_w, self.c_w))
-            return hkls[lin.norm(hkls @ xyz, axis=1) <= radius]
-        hkl = _make_hkl_ball()
-
-        # increase the ball size until all needed points are in
-        previous_length = -1
-        while len(hkl) > previous_length and max_index <= self.HKL_LIMIT:
-            previous_length = len(hkl)
-            max_index = max_index * 2
-            hkl = _make_hkl_ball(max_index)
-
-        # create new dataframe using obtained ball of data
-        _h, _k, _l = np.vsplit(hkl.T, 3)
-        ones = np.ones_like(np.array(_h)[0])
-        self.from_dict({'h': np.array(_h)[0], 'k': np.array(_k)[0],
-                        'l': np.array(_l)[0], 'I': ones, 'si': ones, 'm': ones})
-
-    def fill2(self, radius=2.0):
         max_h = math.ceil(radius / self.a_r)
         max_k = math.ceil(radius / self.b_r)
         max_l = math.ceil(radius / self.c_r)

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -574,11 +574,11 @@ class HklFrame(BaseFrame):
         hkl_ratios = radius / np.array([self.a_r, self.b_r, self.c_r])
         hkl_limits = np.ceil(hkl_ratios).astype(np.int16)
 
-        def hkl_walls(h, k, l):
-            hw = np.mgrid[h:h:1j, -k:k:2j*k+1j, -l:l:2j*l+1j].reshape(3, -1).T
-            kw = np.mgrid[-h:h:2j*h+1j, k:k:1j, -l:l:2j*l+1j].reshape(3, -1).T
-            lw = np.mgrid[-h:h:2j*h+1j, -k:k:2j*k+1j, l:l:1j].reshape(3, -1).T
-            return hw, kw, lw
+        def hkl_walls(h, k, l_):
+            hw = np.mgrid[h:h:1j, -k:k:2j*k+1j, -l_:l_:2j*l_+1j].reshape(3, -1)
+            kw = np.mgrid[-h:h:2j*h+1j, k:k:1j, -l_:l_:2j*l_+1j].reshape(3, -1)
+            lw = np.mgrid[-h:h:2j*h+1j, -k:k:2j*k+1j, l_:l_:1j].reshape(3, -1)
+            return hw.T, kw.T, lw.T
 
         for _ in range(self.HKL_LIMIT):
             limits_too_small = [any(lin.norm(hkls @ self.A_r, axis=1) <= radius)

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -572,37 +572,6 @@ class HklFrame(BaseFrame):
         :param radius: Maximum distance from the reciprocal space origin
             to placed reflection (in reciprocal Angstrom).
         """
-        hkl_limits = np.ceil(radius / np.array([self.a_r, self.b_r, self.c_r]))\
-            .astype(np.int16)
-
-        # make an initial guess of the hkl ball
-        def _make_hkl_ball(lims=hkl_limits):
-            hkls = np.indices(2 * lims + 1, np.int16).reshape(3, -1).T - lims
-            return hkls[lin.norm(hkls @ self.A_r, axis=1) <= radius]
-        hkl = _make_hkl_ball()
-
-        def increment_index_limit(lims: np.ndarray) -> np.ndarray:
-            if any(lims > self.HKL_LIMIT):
-                msg = 'Attempting to use hkl indices {} above HKL_LIMIT of {}'
-                raise ValueError(msg.format(lims, self.HKL_LIMIT))
-            else:
-                return np.clip(np.ceil(lims * 1.1).astype(np.int16),
-                               0, np.int16(self.HKL_LIMIT))
-
-        # increase the ball size until all needed points are in
-        previous_length = -1
-        while len(hkl) > previous_length:
-            previous_length = len(hkl)
-            hkl_limits = increment_index_limit(hkl_limits)
-            hkl = _make_hkl_ball(hkl_limits)
-
-        # create new dataframe using obtained ball of data
-        _h, _k, _l = hkl.T
-        ones = np.ones_like(np.array(_h)[0])
-        self.from_dict({'h': np.squeeze(_h), 'k': np.squeeze(_k),
-                        'l': np.squeeze(_l), 'I': ones, 'si': ones, 'm': ones})
-
-    def fill3(self, radius: float = 2.0) -> None:
         hkl_ratios = radius / np.array([self.a_r, self.b_r, self.c_r])
         hkl_limits = np.ceil(hkl_ratios).astype(np.int16)
 

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -597,10 +597,10 @@ class HklFrame(BaseFrame):
             hkl = _make_hkl_ball(hkl_limits)
 
         # create new dataframe using obtained ball of data
-        _h, _k, _l = np.vsplit(hkl.T, 3)
+        _h, _k, _l = hkl.T
         ones = np.ones_like(np.array(_h)[0])
-        self.from_dict({'h': np.array(_h)[0], 'k': np.array(_k)[0],
-                        'l': np.array(_l)[0], 'I': ones, 'si': ones, 'm': ones})
+        self.from_dict({'h': np.squeeze(_h), 'k': np.squeeze(_k),
+                        'l': np.squeeze(_l), 'I': ones, 'si': ones, 'm': ones})
 
     def stats(self, bins=10, space_group=SG['P1']):
         """

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -361,7 +361,7 @@ class HklFrame(BaseFrame):
     are defined and describe/operate on the :attr:`frame`.
     """
 
-    HKL_LIMIT = 99
+    HKL_LIMIT = 127
     """Highest absolute value of h, k or l index, which can be
     interpreted correctly by current version of the software."""
 
@@ -1333,14 +1333,3 @@ class HklToResConverter:
 
     # TODO wrap table/data in getter/setter and make it automatically place,
     # TODO refresh, set keys etc.
-
-
-if __name__ == "__main__":
-    h1 = HklFrame()
-    h1.edit_cell(a=30, b=30, c=30, al=10, be=10, ga=10)
-    h1.fill()
-    h2 = HklFrame()
-    h2.edit_cell(a=30, b=30, c=30, al=10, be=10, ga=10)
-    h2.fill2()
-    h2.to_res('~/_/skew.res')
-

--- a/hikari/utility/__init__.py
+++ b/hikari/utility/__init__.py
@@ -15,3 +15,4 @@ from .list_tools import cubespace, find_best, rescale_list_to_range,\
 from .os_tools import make_abspath
 from .palettes import gnuplot_map_palette, mpl_map_palette
 from .artists import artist_factory
+from .numpy_tools import str2array

--- a/hikari/utility/numpy_tools.py
+++ b/hikari/utility/numpy_tools.py
@@ -1,0 +1,28 @@
+"""
+This file contains basic tools to work with numpy objects used in the package.
+"""
+
+import re
+import numpy as np
+
+
+def str2array(s: str) -> np.ndarray:
+    """
+    Create a numpy int8 array using its compact representation saved as string.
+    The input string might contain only digits and special characters.
+    Every individual digit is treated as a new element, while the special
+    characters induce special behaviour and include:
+
+    - slash `/` - if present, divides main list into multiple sub-lists;
+    - hyphen `-` - the next digit will be read as negative
+
+    Please mind that the compact form used as this function's input is unfit
+    to store floating point numbers or integers with absolute value above 9.
+
+    :param s: input string containing only digits and special characters
+    :return: a two-dimensional numpy array with integers
+    """
+    elements = [re.findall(r"-?\d", column) for column in s.split('/')]
+    if len({len(element_column) for element_column in elements}) is not 1:
+        raise ValueError('All columns specified with "/" must have same length')
+    return np.array(elements, dtype=np.int8)

--- a/test/test_dataframes.py
+++ b/test/test_dataframes.py
@@ -326,6 +326,19 @@ class TestHklFrame(unittest.TestCase):
         self.assertAlmostEqual(sum(xyz.sum(axis=0) - expected_xyz_sum), 0.0)
         self.assertAlmostEqual(sum(xyz.mean(axis=0) - expected_xyz_mean), 0.0)
 
+    def test_fill(self):
+        self.h2.fill(radius=2.0)
+        self.assertEqual(len(self.h2), 6030)
+        self.h2.edit_cell(a=3, b=10, c=30)
+        self.h2.fill(radius=2.0)
+        self.assertEqual(len(self.h2), 29872)
+        self.h2.edit_cell(a=10, b=10, c=10, al=100, be=100, ga=100)
+        self.h2.fill(radius=2.0)
+        self.assertEqual(len(self.h2), 31734)
+        self.h2.edit_cell(a=99, b=99, c=99)
+        with self.assertRaises(ValueError):
+            self.h2.fill(radius=2.0)
+
     def test_trim(self):
         self.h2.place()
         self.h2.trim(limit=1.2)

--- a/test/test_utility.py
+++ b/test/test_utility.py
@@ -159,6 +159,24 @@ class TestListTools(unittest.TestCase):
         self.assertEqual(''.join(rescale_list_to_other([1, 4], 'Test')), 'Tt')
 
 
+class TestNumpyTools(unittest.TestCase):
+    def test_str2array_simple(self):
+        self.assertTrue(np.allclose(str2array('123'), np.array([1, 2, 3])))
+
+    def test_str2array_with_minus(self):
+        self.assertTrue(np.allclose(str2array('-12-3'), np.array([-1, 2, -3])))
+
+    def test_str2array_with_slash(self):
+        self.assertTrue(np.allclose(str2array('100/010/001'), np.eye(3)))
+
+    def test_str2array_with_all_special_characters(self):
+        self.assertTrue(np.allclose(str2array('9/-8'), np.array([(9,), (-8,)])))
+
+    def test_str2array_raises_value_error_for_uneven_input(self):
+        with self.assertRaises(ValueError):
+            _ = str2array('12/3')
+
+
 class TestMathTools(unittest.TestCase):
     def test_angle2rad(self):
         self.assertEqual(angle2rad(-5), -0.08726646259971647)


### PR DESCRIPTION
In order to decrease the amount of memory used by program, it was planned to perform a Selling reduction of the cell before working with it. However, it was found that this would require major rewriting of `BaseFrame` and thus, due to time constraints, it was abandoned. Instead, the algorithm of `HklFrame.fill` was significantly simplified. The tests and estimations show that the current version should be approximately 10x faster use up to anything less than 10% of previously used memory. This was done in particular to increase the range of possible calculations on recently-deployed dtools.pl, but also it will make calculations faster for an average user. 