### PR TITLE
Futureproof

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,11 +7,12 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   # This workflow contains a single job called "build"
   build:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.6', '3.10' ]
-    name: Python ${{ matrix.python-version }} tests
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.10]
+    runs-on: ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }} tests
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.10']
+        python-version: ['3.10']
+        include:
+          - os: ubuntu-20.04
+            python-version: '3.6'
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} tests
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.10]
+        python-version: ['3.6', '3.10']
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} tests
 

--- a/hikari/dataframes/hkl.py
+++ b/hikari/dataframes/hkl.py
@@ -535,12 +535,14 @@ class HklFrame(BaseFrame):
         :type point_group: hikari.symmetry.Group
         """
         inc = 10 ** (int(np.log10(self.HKL_LIMIT)) + 2)
+        equiv_dtype = self.keys.get_property('equiv', 'dtype')
         self.keys.add(('equiv',))
         self.table.reset_index(drop=True, inplace=True)
         self.table['equiv'] = -inc**3
         _hkl_matrix = self.table.loc[:, ('h', 'k', 'l')].to_numpy()
         for op in point_group.operations:
-            new_equiv = op.transform(_hkl_matrix) @ np.array([inc ** 2, inc, 1])
+            _new_hkl_matrix = op.transform(_hkl_matrix).astype(equiv_dtype)
+            new_equiv = _new_hkl_matrix @ np.array([inc ** 2, inc, 1])
             _to_update = self.table['equiv'] < new_equiv
             self.table.loc[_to_update, 'equiv'] = new_equiv[_to_update]
 

--- a/hikari/scripts/compare_adps.py
+++ b/hikari/scripts/compare_adps.py
@@ -94,7 +94,7 @@ def calculate_similarity_indices(cif1_path: str,
         cif1p = make_abspath(cif1_path)
         cif2p = cif1p if cif2_path is None else make_abspath(cif2_path)
         cif1b = 1 if cif1_block is None else cif1_block
-        cif2b = 2 if cif1b is 1 and cif1p is cif2p \
+        cif2b = 2 if cif1b == 1 and cif1p is cif2p \
             else 1 if cif2_block is None else cif2_block
         return cif1p, cif2p, cif1b, cif2b
     cif1_path, cif2_path, cif1_block, cif2_block = interpret_paths()
@@ -181,7 +181,7 @@ def calculate_similarity_indices(cif1_path: str,
             print(f'{k:>8} {si_string(sis[k])}', file=f)
         sis_all = [v for k, v in sis.items()]
         sis_h = [v for k, v in sis.items()
-                 if k[0] is 'H' and k[:2] not in chemical_elements]
+                 if k[0] == 'H' and k[:2] not in chemical_elements]
         if sis_all:
             avg_si_all = sum(sis_all) / len(sis_all)
             print(f'# avg(*) {si_string(avg_si_all)}', file=f)

--- a/hikari/utility/artists.py
+++ b/hikari/utility/artists.py
@@ -241,8 +241,11 @@ class MatplotlibAngularHeatmapArtist(MatplotlibArtist, AngularHeatmapArtist):
         x_mesh, y_mesh, z_mesh = sph2cart(r=np.ones_like(polar_mesh),
                                           p=np.deg2rad(polar_mesh),
                                           a=np.deg2rad(azimuth_mesh))
-        np.warnings.filterwarnings('ignore',  # mpl uses depreciated numpy
-                                   category=np.VisibleDeprecationWarning)
+        try:
+            np.warnings.filterwarnings('ignore',  # mpl uses depreciated numpy
+                                       category=np.VisibleDeprecationWarning)
+        except AttributeError:
+            pass
         ax.plot_wireframe(x_mesh, y_mesh, z_mesh, colors='k', linewidth=0.25)
 
         # color map declarations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib>=3.0.0,!=3.3.*
 numpy>=1.18.1
-pandas>=1.0.1
+pandas>=1.0.1,!=1.5.0
 seaborn>=0.11.0
 scipy>=1.5.1
 uncertainties>=3.*


### PR DESCRIPTION
Before, tests run only on ubuntu version 20.04 with `python 3.6`. Now, three additional test configurations were added: `python 3.10` on `ubuntu-latest`, `macos-latest`, and `windows-latest`. This was motivated by some tests failing on my Mac installation. Ultimately the issue lied in a bug in `pandas 1.5.0`, which consecutively was rejected from requirements.