### PR TITLE
Split `SymmOp` into `Operation` and `BoundedOperation`

### DIFF
--- a/hikari/symmetry/__init__.py
+++ b/hikari/symmetry/__init__.py
@@ -3,7 +3,7 @@ Module containing symmetry operations and point groups
 to be used by other objects.
 """
 
-from .operations import SymmOp
+from .operations import Operation, BoundedOperation, PointOperation
 from .group import Group
 from .hall import HallSymbol
 from .catalog import GroupCatalog, PG, SG

--- a/hikari/symmetry/catalog.py
+++ b/hikari/symmetry/catalog.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from hikari.resources import (point_groups_json, space_groups_json,
                               point_groups_dataframe, space_groups_dataframe)
-from hikari.symmetry import SymmOp
+from hikari.symmetry.operations import BoundedOperation
 from hikari.utility.typing import PathLike
 from hikari.symmetry.group import Group
 
@@ -201,8 +201,8 @@ class GroupCatalogJSONDecoder(json.JSONDecoder):
             for record in obj['table']:
                 group = record['group']
                 group = Group.from_generators_operations(
-                    generators=[SymmOp.from_code(c) for c in group['generators']],
-                    operations=[SymmOp.from_code(c) for c in group['operations']])
+                    generators=[BoundedOperation.from_code(c) for c in group['generators']],
+                    operations=[BoundedOperation.from_code(c) for c in group['operations']])
                 record.update({'group': group})
                 records.append(record)
             return GroupCatalog(table=pd.DataFrame.from_records(records))

--- a/hikari/symmetry/catalog.py
+++ b/hikari/symmetry/catalog.py
@@ -203,6 +203,8 @@ class GroupCatalogJSONDecoder(json.JSONDecoder):
                 group = Group.from_generators_operations(
                     generators=[BoundedOperation.from_code(c) for c in group['generators']],
                     operations=[BoundedOperation.from_code(c) for c in group['operations']])
+                group.name = record['HM']
+                group.number = record['number']
                 record.update({'group': group})
                 records.append(record)
             return GroupCatalog(table=pd.DataFrame.from_records(records))

--- a/hikari/symmetry/group.py
+++ b/hikari/symmetry/group.py
@@ -196,15 +196,12 @@ class Group:
 
     @property
     def system(self) -> System:
-        """
-        :return: Predicted crystal system associated with this group
-        :rtype: self.CrystalSystem()
-        """
+        """Predicted crystal system associated with this group"""
         folds = [op.fold for op in self.operations]
         orients = [op.orientation for op in self.operations]
 
         def _is_many(_orients):
-            return any([np.dot(_orients[0], o) < 0.99 for o in _orients[1:]])
+            return any([abs(np.dot(_orients[0], o)) < 0.99 for o in _orients[1:]])
 
         if 6 in folds:
             return self.System.hexagonal

--- a/hikari/symmetry/group.py
+++ b/hikari/symmetry/group.py
@@ -131,7 +131,7 @@ class Group:
             best_axis = find_best(ops, self.AXIS_PRIORITY_RULES)
             best_plane = find_best(ops, self.PLANE_PRIORITY_RULES)
             sep = '/' if len(best_axis) > 0 and len(best_plane) > 0 else ''
-            name += ' ' + best_axis + sep + best_plane
+            name += '_' + best_axis + sep + best_plane
         return name.strip()
 
     @property

--- a/hikari/symmetry/hall.py
+++ b/hikari/symmetry/hall.py
@@ -3,7 +3,7 @@ from typing import List, Match, Union
 
 import numpy as np
 
-from hikari.symmetry.operations import SymmOp
+from hikari.symmetry.operations import BoundedOperation
 from hikari.utility import dict_union
 
 
@@ -45,20 +45,28 @@ class HallSymbol:
     DIRECTION_SYMBOLS = ("'", '"', '*')
     TRANSLATION_SYMBOLS = '12345abcnuvwd'
     LATTICE_GENERATORS = {
-        'p': (SymmOp(np.eye(3)), ),
-        'a': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (0, 1 / 2, 1 / 2))),
-        'b': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (1 / 2, 0, 1 / 2))),
-        'c': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (1 / 2, 1 / 2, 0))),
-        'i': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (1 / 2, 1 / 2, 1 / 2))),
-        'r': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (2 / 3, 1 / 3, 1 / 3)),
-              SymmOp(np.eye(3), (1 / 3, 2 / 3, 2 / 3))),
-        's': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (1 / 3, 1 / 3, 2 / 3)),
-              SymmOp(np.eye(3), (2 / 3, 2 / 3, 1 / 3))),
-        't': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (1 / 3, 2 / 3, 1 / 3)),
-              SymmOp(np.eye(3), (2 / 3, 1 / 3, 2 / 3))),
-        'f': (SymmOp(np.eye(3)), SymmOp(np.eye(3), (0, 1 / 2, 1 / 2)),
-              SymmOp(np.eye(3), (1 / 2, 0, 1 / 2)),
-              SymmOp(np.eye(3), (1 / 2, 1 / 2, 0))),
+        'p': (BoundedOperation(np.eye(3)),),
+        'a': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (0, 1 / 2, 1 / 2))),
+        'b': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (1 / 2, 0, 1 / 2))),
+        'c': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (1 / 2, 1 / 2, 0))),
+        'i': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (1 / 2, 1 / 2, 1 / 2))),
+        'r': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (2 / 3, 1 / 3, 1 / 3)),
+              BoundedOperation(np.eye(3), (1 / 3, 2 / 3, 2 / 3))),
+        's': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (1 / 3, 1 / 3, 2 / 3)),
+              BoundedOperation(np.eye(3), (2 / 3, 2 / 3, 1 / 3))),
+        't': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (1 / 3, 2 / 3, 1 / 3)),
+              BoundedOperation(np.eye(3), (2 / 3, 1 / 3, 2 / 3))),
+        'f': (BoundedOperation(np.eye(3)),
+              BoundedOperation(np.eye(3), (0, 1 / 2, 1 / 2)),
+              BoundedOperation(np.eye(3), (1 / 2, 0, 1 / 2)),
+              BoundedOperation(np.eye(3), (1 / 2, 1 / 2, 0))),
     }
     UNIVERSAL_MATRICES = {
         '1': np.eye(3),
@@ -142,13 +150,13 @@ class HallSymbol:
         self._symbol = symbol.lower().replace(' ', '_')
 
     @property
-    def generators(self) -> List[SymmOp]:
+    def generators(self) -> List[BoundedOperation]:
         elements: re.Match = self.elements
 
         # lattice / centering generators
-        generators: List[SymmOp] = list(self.LATTICE_GENERATORS[elements[2]])
+        generators: List[BoundedOperation] = list(self.LATTICE_GENERATORS[elements[2]])
         if elements[1] == '-':
-            generators.append(SymmOp(-np.eye(3)))
+            generators.append(BoundedOperation(-np.eye(3)))
 
         # generator 1
         gen1_inv, gen1_fold, gen1_dir, gen1_tl = elements.group(3, 4, 5, 6)
@@ -163,7 +171,7 @@ class HallSymbol:
         gen1_translations = dict_union(*gen1_translation_dicts)
         for tl in gen1_tl:
             tl1 += gen1_translations[tl]
-        generators.append(SymmOp(tf1, tl1))
+        generators.append(BoundedOperation(tf1, tl1))
 
         # generator 2
         gen2_inv, gen2_fold, gen2_dir, gen2_tl = elements.group(7, 8, 9, 10)
@@ -181,7 +189,7 @@ class HallSymbol:
             tl2 = np.array([0., 0., 0.])
             for tl in gen2_tl:
                 tl2 += self.STATIC_TRANSLATIONS[tl]
-            generators.append(SymmOp(tf2, tl2))
+            generators.append(BoundedOperation(tf2, tl2))
 
         # generator 3
         gen3_inv, gen3_fold, gen3_tl = elements.group(11, 12, 13)
@@ -191,7 +199,7 @@ class HallSymbol:
             tl3 = np.array([0., 0., 0.])
             for tl in gen3_tl:
                 tl3 += self.STATIC_TRANSLATIONS[tl]
-            generators.append(SymmOp(tf3, tl3))
+            generators.append(BoundedOperation(tf3, tl3))
 
         # generator 4
         gen4_fold, gen4_tl = elements.group(14, 15)
@@ -199,14 +207,14 @@ class HallSymbol:
             tl4 = np.array([0., 0., 0.])
             for tl in gen4_tl:
                 tl4 += self.STATIC_TRANSLATIONS[tl]
-            generators.append(SymmOp(-np.eye(3), tl4))
+            generators.append(BoundedOperation(-np.eye(3), tl4))
 
         if any(elements.group(16, 17, 18)):
             shift_ints = [int(i) for i in elements.group(16, 17, 18)]
             shift_vector = np.array(shift_ints, dtype=float) / 12
-            shift_op_left = SymmOp(np.eye(3), shift_vector)
-            shift_op_right = SymmOp(np.eye(3), -shift_vector)
-            generators = [SymmOp.from_matrix(shift_op_left.matrix @ g.matrix
-                          @ shift_op_right.matrix) for g in generators]
+            shift_op_left = BoundedOperation(np.eye(3), shift_vector)
+            shift_op_right = BoundedOperation(np.eye(3), -shift_vector)
+            generators = [BoundedOperation.from_matrix(shift_op_left.matrix @ g.matrix
+                                                @ shift_op_right.matrix) for g in generators]
 
         return generators

--- a/hikari/symmetry/operations.py
+++ b/hikari/symmetry/operations.py
@@ -97,11 +97,8 @@ class Operation:
         and 3-length translation vector. Alias for standard creation method.
 
         :param matrix: 3x3 point transformation matrix
-        :type matrix: np.ndarray
         :param vector: 3-length translation vector
-        :type vector: np.ndarray
         :return: Symmetry operation generated based on matrix - vector pair
-        :rtype: Operation
         """
         return cls(matrix, vector)
 
@@ -156,10 +153,7 @@ class Operation:
 
     @property
     def matrix(self) -> np.ndarray:
-        """
-        :return: Augmented 4 x 4 transformation matrix with float-type values
-        :rtype: np.ndarray
-        """
+        """Augmented 4 x 4 transformation matrix with float-type values"""
         matrix = np.eye(4, dtype=float)
         matrix[0:3, 0:3] = self.tf
         matrix[0:3, 3] = self.tl
@@ -348,11 +342,8 @@ class Operation:
         Will most likely not work for unimplemented rhombohedral unit cells.
 
         :param direction: Target orientation for element of symmetry operation
-        :type direction: np.ndarray
         :param hexagonal: True if operation is defined in hexagonal coordinates
-        :type hexagonal: bool
         :return: New symmetry operation whose orientation is "direction"
-        :rtype: Operation
         """
         rebase = np.array(((1, -1/2, 0), (0, np.sqrt(3)/2, 0), (0, 0, 1))) \
             if hexagonal else np.eye(3)
@@ -393,9 +384,7 @@ class Operation:
         Transform a column containing rows of coordinate points
 
         :param other: A vertical numpy array of coordinate triplets kept in rows
-        :type other: np.ndarray
         :return: Same-shaped array of coordinate triplets transformed by self
-        :rtype: np.ndarray
         """
         if other.shape[1] == 3:
             return (self.tf @ other.T).T + self.tl

--- a/hikari/symmetry/operations.py
+++ b/hikari/symmetry/operations.py
@@ -294,7 +294,9 @@ class Operation:
             return None
         if o is None:
             return o
-        o = o if sum(o) > 0 else -o
+        o = o if sum(o) >= 0 else -o
+        if self.typ is self.Type.rotoinversion:  # same direction as glide
+            o = o if np.dot(o, self.glide) > 0 else -o
         return o / np.sqrt(sum(o*o))
 
     @property

--- a/hikari/symmetry/operations.py
+++ b/hikari/symmetry/operations.py
@@ -261,17 +261,6 @@ class Operation:
         """
         return (self.unbounded() ** 24)._tl24 / 576
 
-    # TODO There is a big issue with the interpretation of symmetry operations
-    # Originally, `glide` would return `(self ** 24)._tl24 / 576 % 1`
-    # This is because this class was designed mostly to work with periodic
-    # systems and "operations" collapsed to the unit cell.
-    # This means that glide (1/3, -1/3, 0) would collapse to (1/3, 2/3, 0),
-    # which is correct in periodic conditions, but does not describe relations
-    # between two individual molecules in the local space correctly.
-    # There needs to be a distinction between `Operation`s that should
-    # automatically collapse and the ones that do not care for equivalence
-    # but rather are designed to properly transform in non-collapsed space.
-
     @property
     def glide_fold(self) -> int:
         """

--- a/hikari/utility/__init__.py
+++ b/hikari/utility/__init__.py
@@ -17,3 +17,4 @@ from .os_tools import make_abspath
 from .palettes import gnuplot_map_palette, mpl_map_palette
 from .artists import artist_factory
 from .numpy_tools import str2array
+from .singleton import Singleton

--- a/hikari/utility/singleton.py
+++ b/hikari/utility/singleton.py
@@ -1,0 +1,10 @@
+class Singleton(type):
+    """
+    A metaclass based on https://stackoverflow.com/q/6760685/.
+    Declare a singleton class using `MyClass(BaseClass, metaclass=Singleton)`
+    """
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,14 @@
 """
 Set environment variable "HIKARI_TESTS_RAPID=True" to skip the slowest tests.
 """
+
+from unittest import TestCase
+
+import numpy as np
+
+
+class NumpyTestCase(TestCase):
+    def assertAllClose(self, a, b, **kwargs):
+        if kwargs.get('atol', None) is None:
+            kwargs['atol'] = 1e-15
+        self.assertIsNone(np.testing.assert_allclose(a, b, **kwargs))

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -87,3 +87,12 @@ class TestSpaceGroupCatalog(TestPointGroupCatalog):
     catalogue_length: int = 530
     catalogue_standards: int = 230
     catalogue_sample_HM_simple: str = 'P2/m'
+
+    def test_group_catalogs_auto_generated_names(self):
+        print(len(self.catalogue_object.standard.values()))
+        for group in self.catalogue_object.standard.values():
+            with self.subTest(group_id=group.number):
+                hardcoded_name = group.name
+                generated_name = group.auto_generated_name
+                print(f'{group.number=}, {group.name=}, {generated_name=}, {group.operations=}')
+                self.assertEqual(hardcoded_name, generated_name)

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -5,7 +5,7 @@ import warnings
 
 from hikari.resources import (point_groups_dataframe, space_groups_dataframe,
                               point_groups_json, space_groups_json)
-from hikari.symmetry import Group, PG, SymmOp, SG
+from hikari.symmetry import BoundedOperation, Group, PG, SG
 from hikari.symmetry.catalog import GroupCatalog, AmbiguousGroupAccessorWarning
 
 import pandas as pd
@@ -17,7 +17,7 @@ class TestGroup(unittest.TestCase):
             'x,y,z', '-x+1/2,-y,z+1/2', '-x,y+1/2,-z+1/2', 'z,x,y',
             'y+3/4,x+1/4,-z+1/4', '-x,-y,-z', 'x+1/2,y+1/2,z+1/2'
         ]
-        sg230_generators = [SymmOp.from_code(c) for c in sg230_generator_codes]
+        sg230_generators = [BoundedOperation.from_code(c) for c in sg230_generator_codes]
         _ = Group(*sg230_generators)
 
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -87,12 +87,3 @@ class TestSpaceGroupCatalog(TestPointGroupCatalog):
     catalogue_length: int = 530
     catalogue_standards: int = 230
     catalogue_sample_HM_simple: str = 'P2/m'
-
-    def test_group_catalogs_auto_generated_names(self):
-        print(len(self.catalogue_object.standard.values()))
-        for group in self.catalogue_object.standard.values():
-            with self.subTest(group_id=group.number):
-                hardcoded_name = group.name
-                generated_name = group.auto_generated_name
-                print(f'{group.number=}, {group.name=}, {generated_name=}, {group.operations=}')
-                self.assertEqual(hardcoded_name, generated_name)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -142,7 +142,7 @@ class TestOperations(TestSelectedOperations):
         self.assertEqual(self.sg40_a.sense, '')
         self.assertEqual(self.sg40_21.sense, '')
         self.assertEqual(self.sg40_n.sense, '')
-        self.assertEqual(self.sg147_m3.sense, '+')
+        self.assertEqual(self.sg147_m3.sense, '-')
 
     def test_at(self):
         self.assertEqual(self.sg40_a.at(p111).code, 'x+1/2,-y+2,z')

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,9 +1,9 @@
 import unittest
-from hikari.symmetry import SymmOp
+from hikari.symmetry import Operation
 import numpy as np
 
 
-class TestSymmOp(unittest.TestCase):
+class TestOperation(unittest.TestCase):
     sg40_a_tf = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
     sg40_a_tl = np.array([1 / 2, 0, 0])
     sg40_a_m = np.array([[1, 0, 0, .5], [0, -1, 0, 0],
@@ -14,59 +14,66 @@ class TestSymmOp(unittest.TestCase):
     sg147_m3_code = 'x - y, x, -z'
 
     def test_from_pair(self):
-        o = SymmOp.from_pair(self.sg40_a_tf, self.sg40_a_tl)
+        o = Operation.from_pair(self.sg40_a_tf, self.sg40_a_tl)
         self.assertTrue(np.allclose(self.sg40_a_tf, o.tf))
         self.assertTrue(np.allclose(self.sg40_a_tl, o.tl))
 
     def test_from_code(self):
-        o = SymmOp.from_code(self.sg40_a_code)
+        o = Operation.from_code(self.sg40_a_code)
         self.assertTrue(np.allclose(self.sg40_a_tf, o.tf))
         self.assertTrue(np.allclose(self.sg40_a_tl, o.tl))
 
     def test_from_matrix(self):
-        o = SymmOp.from_matrix(self.sg40_a_m)
+        o = Operation.from_matrix(self.sg40_a_m)
         self.assertTrue(np.allclose(self.sg40_a_tf, o.tf))
         self.assertTrue(np.allclose(self.sg40_a_tl, o.tl))
 
     def test_maths(self):
-        o1 = SymmOp.from_code(self.sg40_a_code)
-        o2 = SymmOp.from_code(self.sg40_21_code)
-        o3 = SymmOp.from_code(self.sg40_n_code)
-        self.assertEqual(o1 * o2 % 1, o3 % 1)
+        o1 = Operation.from_code(self.sg40_a_code)
+        o2 = Operation.from_code(self.sg40_21_code)
+        o3 = Operation.from_code(self.sg40_n_code)
+        self.assertEqual(o1 * o2, o3)
         self.assertEqual(o1*o1, o1**2)
         self.assertEqual(o1*o1*o1*o1*o1, o1**5)
 
     def test_repr(self):
-        o1 = SymmOp.from_code(self.sg40_a_code)
-        o2 = SymmOp.from_code(self.sg40_21_code)
-        o3 = SymmOp.from_code(self.sg40_n_code)
+        o1 = Operation.from_code(self.sg40_a_code)
+        o2 = Operation.from_code(self.sg40_21_code)
+        o3 = Operation.from_code(self.sg40_n_code)
         self.assertEqual(o1, eval(repr(o1)))
         self.assertEqual(o2, eval(repr(o2)))
         self.assertEqual(o3, eval(repr(o3)))
 
     def test_det_and_trace(self):
-        o1 = SymmOp.from_code(self.sg40_a_code)
-        o2 = SymmOp.from_code(self.sg40_21_code)
+        o1 = Operation.from_code(self.sg40_a_code)
+        o2 = Operation.from_code(self.sg40_21_code)
         self.assertEqual(o1.det, -1)
         self.assertEqual(o2.det, 1)
         self.assertEqual(o1.trace, 1)
         self.assertEqual(o2.trace, -1)
 
     def test_fold_and_order(self):
-        o1 = SymmOp.from_code(self.sg40_a_code)
-        o2 = SymmOp.from_code(self.sg147_m3_code)
+        o1 = Operation.from_code(self.sg40_a_code)
+        o2 = Operation.from_code(self.sg147_m3_code)
         self.assertEqual(o1.fold, 2)
         self.assertEqual(o2.fold, 3)
         self.assertEqual(o1.order, 2)
         self.assertEqual(o2.order, 6)
 
     def test_typ(self):
-        o1 = SymmOp.from_code(self.sg40_a_code)
-        o2 = SymmOp.from_code(self.sg40_21_code)
-        o3 = SymmOp.from_code(self.sg147_m3_code)
+        o1 = Operation.from_code(self.sg40_a_code)
+        o2 = Operation.from_code(self.sg40_21_code)
+        o3 = Operation.from_code(self.sg147_m3_code)
         self.assertIs(o1.typ, o1.Type.transflection)
         self.assertIs(o2.typ, o2.Type.rototranslation)
         self.assertIs(o3.typ, o3.Type.rotoinversion)
+
+    def test_extincts(self):
+        o1 = Operation.from_code(self.sg40_a_code)
+        o2 = Operation.from_code(self.sg40_21_code)
+        test_reflections = np.array([[0, 0, 1], [0, 0, 2], [1, 0, 1]])
+        self.assertEqual(list(o1.extincts(test_reflections)), [False, False, True])
+        self.assertEqual(list(o2.extincts(test_reflections)), [True, False, False])
 
 
 if __name__ == '__main__':

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,79 +1,254 @@
 import unittest
-from hikari.symmetry import Operation
+
 import numpy as np
 
+from tests import NumpyTestCase
+from hikari.symmetry import Operation, BoundedOperation, PointOperation
 
-class TestOperation(unittest.TestCase):
-    sg40_a_tf = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
-    sg40_a_tl = np.array([1 / 2, 0, 0])
-    sg40_a_m = np.array([[1, 0, 0, .5], [0, -1, 0, 0],
-                         [0, 0, 1, 0], [0, 0, 0, 1]])
-    sg40_a_code = '1/2+x,-y,z'
-    sg40_21_code = '-x,-y+1/2,z+1/2'
-    sg40_n_code = '-x+1/2,y-1/2,z+1/2'
-    sg147_m3_code = 'x - y, x, -z'
 
+p100 = np.array([1, 0, 0])
+p010 = np.array([0, 1, 0])
+p110 = np.array([1, 1, 0])
+p111 = np.array([1, 1, 1])
+
+x = np.array([1, 0, 0])
+y = np.array([0, 1, 0])
+z = np.array([0, 0, 1])
+
+sg40_a_tf = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
+sg40_a_tl = np.array([1 / 2, 0, 0])
+sg40_a_m = np.array([[1, 0, 0, .5], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+sg40_a_code = 'x+1/2,-y,z'
+sg40_21_code = '-x,-y+1/2,z+1/2'
+sg40_n_code = '-x+1/2,y-1/2,z+1/2'
+sg147_m3_code = 'x-y,x,-z'
+
+
+class TestOperationsInit(unittest.TestCase):
     def test_from_pair(self):
-        o = Operation.from_pair(self.sg40_a_tf, self.sg40_a_tl)
-        self.assertTrue(np.allclose(self.sg40_a_tf, o.tf))
-        self.assertTrue(np.allclose(self.sg40_a_tl, o.tl))
+        o = Operation.from_pair(sg40_a_tf, sg40_a_tl)
+        self.assertTrue(np.allclose(sg40_a_tf, o.tf))
+        self.assertTrue(np.allclose(sg40_a_tl, o.tl))
 
     def test_from_code(self):
-        o = Operation.from_code(self.sg40_a_code)
-        self.assertTrue(np.allclose(self.sg40_a_tf, o.tf))
-        self.assertTrue(np.allclose(self.sg40_a_tl, o.tl))
+        o = Operation.from_code(sg40_a_code)
+        self.assertTrue(np.allclose(sg40_a_tf, o.tf))
+        self.assertTrue(np.allclose(sg40_a_tl, o.tl))
 
     def test_from_matrix(self):
-        o = Operation.from_matrix(self.sg40_a_m)
-        self.assertTrue(np.allclose(self.sg40_a_tf, o.tf))
-        self.assertTrue(np.allclose(self.sg40_a_tl, o.tl))
+        o = Operation.from_matrix(sg40_a_m)
+        self.assertTrue(np.allclose(sg40_a_tf, o.tf))
+        self.assertTrue(np.allclose(sg40_a_tl, o.tl))
 
-    def test_maths(self):
-        o1 = Operation.from_code(self.sg40_a_code)
-        o2 = Operation.from_code(self.sg40_21_code)
-        o3 = Operation.from_code(self.sg40_n_code)
-        self.assertEqual(o1 * o2, o3)
-        self.assertEqual(o1*o1, o1**2)
-        self.assertEqual(o1*o1*o1*o1*o1, o1**5)
+
+class TestSelectedOperations(NumpyTestCase):
+    """Define space group #40 'Ama2' operations here to avoid code repetition"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sg40_a = Operation.from_code(sg40_a_code)
+        cls.sg40_21 = Operation.from_code(sg40_21_code)
+        cls.sg40_n = Operation.from_code(sg40_n_code)
+        cls.sg147_m3 = Operation.from_code(sg147_m3_code)
+        cls.operations = [cls.sg40_a, cls.sg40_21, cls.sg40_n, cls.sg147_m3]
+
+
+class TestOperations(TestSelectedOperations):
+    """Test selected aspects specific to `Operation`s"""
+
+    def test_equals(self):
+        self.assertEqual(self.sg40_a, self.sg40_a)
+        self.assertNotEqual(self.sg40_a, self.sg40_21)
+        self.assertNotEqual(self.sg40_a, 42)
+
+    def test_product(self):
+        self.assertEqual(self.sg40_a * self.sg40_21, self.sg40_n)
+
+    def test_power(self):
+        for o in self.operations:
+            self.assertEqual(o*o, o**2)
+            self.assertEqual(o*o*o*o*o, o**5)
+
+    def test_inverse(self):
+        identity = Operation.from_code('x,y,z')
+        for o in self.operations:
+            self.assertEqual(o * (o ** -1), identity)
+            self.assertEqual((o ** -1) * o, identity)
+            self.assertEqual(o * pow(o, -1), identity)
 
     def test_repr(self):
-        o1 = Operation.from_code(self.sg40_a_code)
-        o2 = Operation.from_code(self.sg40_21_code)
-        o3 = Operation.from_code(self.sg40_n_code)
-        self.assertEqual(o1, eval(repr(o1)))
-        self.assertEqual(o2, eval(repr(o2)))
-        self.assertEqual(o3, eval(repr(o3)))
+        for o in self.operations:
+            self.assertEqual(o, eval(repr(o)))
 
-    def test_det_and_trace(self):
-        o1 = Operation.from_code(self.sg40_a_code)
-        o2 = Operation.from_code(self.sg40_21_code)
-        self.assertEqual(o1.det, -1)
-        self.assertEqual(o2.det, 1)
-        self.assertEqual(o1.trace, 1)
-        self.assertEqual(o2.trace, -1)
+    def test_str(self):
+        self.assertEqual(str(self.sg40_a), 'a: x+1/2,-y,z (0,0,0)')
+        self.assertEqual(str(self.sg40_21), '21: -x,-y+1/2,z+1/2 (0,1/4,0)')
+        self.assertEqual(str(self.sg40_n), 'x: -x+1/2,y-1/2,z+1/2 (1/4,0,0)')
 
-    def test_fold_and_order(self):
-        o1 = Operation.from_code(self.sg40_a_code)
-        o2 = Operation.from_code(self.sg147_m3_code)
-        self.assertEqual(o1.fold, 2)
-        self.assertEqual(o2.fold, 3)
-        self.assertEqual(o1.order, 2)
-        self.assertEqual(o2.order, 6)
+    def test_hash(self):
+        for o in self.operations:
+            self.assertIsInstance(hash(o), int)
+
+    def test_code(self):
+        self.assertEqual(self.sg40_a.code, sg40_a_code)
+        self.assertEqual(self.sg40_21.code, sg40_21_code)
+        self.assertEqual(self.sg40_n.code, sg40_n_code)
+        self.assertEqual(self.sg147_m3.code, sg147_m3_code)
+
+    def test_det(self):
+        self.assertEqual(self.sg40_a.det, -1)
+        self.assertEqual(self.sg40_21.det, 1)
+        self.assertEqual(self.sg40_n.det, -1)
+        self.assertEqual(self.sg147_m3.det, -1)
 
     def test_typ(self):
-        o1 = Operation.from_code(self.sg40_a_code)
-        o2 = Operation.from_code(self.sg40_21_code)
-        o3 = Operation.from_code(self.sg147_m3_code)
-        self.assertIs(o1.typ, o1.Type.transflection)
-        self.assertIs(o2.typ, o2.Type.rototranslation)
-        self.assertIs(o3.typ, o3.Type.rotoinversion)
+        self.assertIs(self.sg40_a.typ, Operation.Type.transflection)
+        self.assertIs(self.sg40_21.typ, Operation.Type.rototranslation)
+        self.assertIs(self.sg40_n.typ, Operation.Type.transflection)
+        self.assertIs(self.sg147_m3.typ, Operation.Type.rotoinversion)
+
+    def test_fold(self):
+        self.assertEqual(self.sg40_a.fold, 2)
+        self.assertEqual(self.sg40_21.fold, 2)
+        self.assertEqual(self.sg40_n.fold, 2)
+        self.assertEqual(self.sg147_m3.fold, 3)
+
+    def test_order(self):
+        self.assertEqual(self.sg40_a.order, 2)
+        self.assertEqual(self.sg40_21.order, 2)
+        self.assertEqual(self.sg40_n.order, 2)
+        self.assertEqual(self.sg147_m3.order, 6)
+
+    def test_glide(self):
+        self.assertEqual(self.sg40_a.glide[0], 0.5)
+        self.assertEqual(self.sg40_21.glide[2], 0.5)
+        self.assertEqual(self.sg40_n.glide[1], -0.5)
+        self.assertEqual(self.sg40_n.glide[2], 0.5)
+        self.assertEqual(sum(self.sg147_m3.glide), 0.)
+
+    def test_trace(self):
+        self.assertEqual(self.sg40_a.trace, 1)
+        self.assertEqual(self.sg40_21.trace, -1)
+        self.assertEqual(self.sg40_n.trace, 1)
+        self.assertEqual(self.sg147_m3.trace, 0)
+
+    def test_orientation(self):
+        self.assertEqual(abs(np.dot(self.sg40_a.orientation, y)), 1)
+        self.assertEqual(abs(np.dot(self.sg40_21.orientation, z)), 1)
+        self.assertEqual(abs(np.dot(self.sg40_n.orientation, x)), 1)
+        self.assertEqual(abs(np.dot(self.sg147_m3.orientation, x)), 1)
+
+    def test_sense(self):
+        self.assertEqual(self.sg40_a.sense, '')
+        self.assertEqual(self.sg40_21.sense, '')
+        self.assertEqual(self.sg40_n.sense, '')
+        self.assertEqual(self.sg147_m3.sense, '+')
+
+    def test_at(self):
+        self.assertEqual(self.sg40_a.at(p111).code, 'x+1/2,-y+2,z')
+        self.assertEqual(self.sg40_21.at(p111).code, '-x+2,-y+2,z+1/2')
+        self.assertEqual(self.sg40_n.at(p111).code, '-x+2,y-1/2,z+1/2')
+        self.assertEqual(self.sg147_m3.at(p111).code, 'x-y+1,x,-z+2')
+
+    def test_into(self):
+        self.assertEqual(self.sg40_a.into(z).code, 'x+1/2,y,-z')
+        self.assertEqual(self.sg40_21.into(y).code, '-x,y+1,-z')
+        self.assertEqual(self.sg40_n.into(y).code, 'x+1,-y,z+1/2')
+        self.assertEqual(self.sg147_m3.into(y).code, '-y,x+y,-z')
+
+    def test_transform(self):
+        pp = np.expand_dims(p111, 1).T
+        self.assertAllClose(self.sg40_a.transform(pp), np.array([[1.5, -1., 1.]]))
+        self.assertAllClose(self.sg40_21.transform(pp), np.array([[-1, -0.5, 1.5]]))
+        self.assertAllClose(self.sg40_n.transform(pp), np.array([[-0.5, 0.5, 1.5]]))
+        self.assertAllClose(self.sg147_m3.transform(pp), np.array([[0., 1., -1.]]))
 
     def test_extincts(self):
-        o1 = Operation.from_code(self.sg40_a_code)
-        o2 = Operation.from_code(self.sg40_21_code)
-        test_reflections = np.array([[0, 0, 1], [0, 0, 2], [1, 0, 1]])
-        self.assertEqual(list(o1.extincts(test_reflections)), [False, False, True])
-        self.assertEqual(list(o2.extincts(test_reflections)), [True, False, False])
+        r = np.array([[0, 0, 1], [0, 0, 2], [1, 0, 1], [1, -1, 1]])
+        self.assertEqual(list(self.sg40_a.extincts(r)), [False, False, True, False])
+        self.assertEqual(list(self.sg40_21.extincts(r)), [True, False, False, False])
+        self.assertEqual(list(self.sg40_n.extincts(r)), [True, False, False, False])
+        self.assertEqual(list(self.sg147_m3.extincts(r)), [False, False, False, False])
+
+    def test_distance_to_point(self):
+        self.assertEqual(self.sg40_a.distance_to_point(p111), 1.0)
+        self.assertEqual(self.sg40_21.distance_to_point(p110), 1.25)
+        self.assertEqual(self.sg40_n.distance_to_point(p111), 0.75)
+        self.assertEqual(self.sg147_m3.distance_to_point(p111), np.sqrt(2))
+
+
+class TestBoundedOperations(TestSelectedOperations):
+    """Test selected aspects specific to `BoundedOperation`s"""
+
+    def test_binding(self):
+        self.assertEqual(self.sg40_21, self.sg40_21.bounded)
+        self.assertNotEqual(self.sg40_n, self.sg40_n.bounded)
+        self.assertEqual(self.sg40_n.bounded.code, '-x+1/2,y+1/2,z+1/2')
+
+    def test_unbinding(self):
+        for op in self.operations:
+            self.assertEqual((op.bounded ** 12).tl[0], 0)
+            self.assertEqual((op.bounded ** 12).tl[1], 0)
+            self.assertEqual((op.bounded ** 12).tl[2], 0)
+        self.assertEqual((self.sg40_a.unbounded ** 12).tl[0], 6)
+        self.assertEqual((self.sg40_21.unbounded ** 12).tl[2], 6)
+        self.assertEqual((self.sg40_n.unbounded ** 12).tl[1], -6)
+        self.assertEqual((self.sg40_n.unbounded ** 12).tl[2], 6)
+        self.assertEqual((self.sg147_m3.unbounded ** 12).tl[0], 0)
+
+    def test_is_bounded(self):
+        self.assertTrue(self.sg40_a.is_bounded)
+        self.assertTrue(self.sg40_21.is_bounded)
+        self.assertFalse(self.sg40_n.is_bounded)
+        self.assertTrue(self.sg147_m3.is_bounded)
+
+
+
+
+class TestPointOperations(TestSelectedOperations):
+    """Test selected aspects specific to `BoundedOperation`s"""
+
+    def test_point_restraint(self):
+        for op in [self.sg40_a, self.sg40_21, self.sg40_n]:
+            with self.assertRaises(ValueError):
+                _ = PointOperation(op.tf, op.tl)
+        _ = PointOperation(self.sg147_m3.tf, self.sg147_m3.tl)
+
+
+class TestCatalogOperations(unittest.TestCase):
+    """Run complete rigorous tests on all operations defined in `SG` catalog"""
+
+    @classmethod
+    def setUpClass(cls):
+        from hikari.symmetry import SG
+        cls.operations: list[BoundedOperation] \
+            = list({o for s in SG.values() for o in s.operations})
+
+    def test_catalog_names(self):
+        for op in self.operations:
+            self.assertFalse(op.name.startswith('?'))
+
+    def test_catalog_fold(self):
+        for op in self.operations:
+            self.assertIn(op.fold, {1, 2, 3, 4, 5, 6})
+
+    def test_catalog_order(self):
+        for op in self.operations:
+            self.assertIn(op.order, {1, 2, 3, 4, 5, 6})
+
+    def test_catalog_at_origin(self):
+        for op in self.operations:
+            self.assertEqual(op, op.at(op.origin))
+
+    def test_catalog_into_orientation(self):
+        for op in self.operations:
+            if (orientation := op.orientation) is not None:
+                self.assertEqual(op, op.into(orientation))
+
+    def test_catalog_distance_to_point(self):
+        p_pi = np.array([np.pi, np.pi, np.pi])
+        for op in self.operations:
+            self.assertNotEqual(op.distance_to_point(p_pi), 0.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -101,6 +101,7 @@ class TestHklScripts(unittest.TestCase):
     def test_completeness_statistics(self):
         kwargs = dict({'space_group': 'Fm-3m'}, **nacl_commons)
         stdout = self.get_stdout(completeness_statistics, kwargs)
+        print(stdout)
         line = '(2.373, 2.468]    287      6       6  11.039363'
         self.assertIn(line, stdout)
         # TODO: for some reason, on ubuntu latest ONLY, one refl is not read?

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -101,8 +101,7 @@ class TestHklScripts(unittest.TestCase):
     def test_completeness_statistics(self):
         kwargs = dict({'space_group': 'Fm-3m'}, **nacl_commons)
         stdout = self.get_stdout(completeness_statistics, kwargs)
-        print(stdout)
-        line = '(2.373, 2.468]    287      6       6  11.039363'
+        line = '(2.373, 2.468]    287      6       6  11.039363   1.0   47.833333'
         self.assertIn(line, stdout)
         # TODO: for some reason, on ubuntu latest ONLY, one refl is not read?
         # TODO: check that out eventually - the last reflection not read

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -101,7 +101,7 @@ class TestHklScripts(unittest.TestCase):
     def test_completeness_statistics(self):
         kwargs = dict({'space_group': 'Fm-3m'}, **nacl_commons)
         stdout = self.get_stdout(completeness_statistics, kwargs)
-        line = '(2.373, 2.468]    287      6       6  11.039363   1.0   47.833333'
+        line = '(2.373, 2.468]    293      6       6  11.057517   1.0   48.833333'
         self.assertIn(line, stdout)
         # TODO: for some reason, on ubuntu latest ONLY, one refl is not read?
         # TODO: check that out eventually - the last reflection not read


### PR DESCRIPTION
Previously, the single `SymmOp` class described all symmetry operations, whenever they were meant to be Coset representatives or "free" operations of any transformations. This led to some errors, e.g.: incorrect directions, threefold axes in cubic systems causing some extinctions, incorrect glide or sense calculations. This PR splits class `SymmOp` into `Operation` and `BoundedOperation` (as well as `PointOperation` which is not widely applied) so that an appropriate class can be used in appropriate case and the "binding" of `Operation`s into the unit box is always done automatically and correctly.